### PR TITLE
feat: add Blake2b-256 and hex encoding via @noble/hashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "cardano-mpfs-browser-issue-6",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@noble/hashes": "^2.0.1"
+  }
+}

--- a/spago.yaml
+++ b/spago.yaml
@@ -1,6 +1,7 @@
 package:
   name: mpfs-explorer
   dependencies:
+    - arraybuffer-types
     - prelude
     - effect
     - aff

--- a/src/MPFS/Crypto/Hash.js
+++ b/src/MPFS/Crypto/Hash.js
@@ -1,0 +1,9 @@
+import { blake2b } from "@noble/hashes/blake2.js";
+import {
+  bytesToHex,
+  hexToBytes,
+} from "@noble/hashes/utils.js";
+
+export const blake2b256Impl = (bytes) => blake2b(bytes, { dkLen: 32 });
+export const bytesToHexImpl = bytesToHex;
+export const hexToBytesImpl = hexToBytes;

--- a/src/MPFS/Crypto/Hash.purs
+++ b/src/MPFS/Crypto/Hash.purs
@@ -1,0 +1,32 @@
+-- | Blake2b-256 hashing and hex encoding via
+-- @noble/hashes. These are the cryptographic
+-- primitives used throughout the MPFS verification
+-- chain.
+module MPFS.Crypto.Hash
+  ( blake2b256
+  , bytesToHex
+  , hexToBytes
+  ) where
+
+import Data.ArrayBuffer.Types (Uint8Array)
+
+-- | Blake2b-256 hash (32-byte digest).
+foreign import blake2b256Impl :: Uint8Array -> Uint8Array
+
+-- | Encode bytes as hex string.
+foreign import bytesToHexImpl :: Uint8Array -> String
+
+-- | Decode hex string to bytes.
+foreign import hexToBytesImpl :: String -> Uint8Array
+
+-- | Hash a byte array with Blake2b-256.
+blake2b256 :: Uint8Array -> Uint8Array
+blake2b256 = blake2b256Impl
+
+-- | Encode a byte array as a hex string.
+bytesToHex :: Uint8Array -> String
+bytesToHex = bytesToHexImpl
+
+-- | Decode a hex string to a byte array.
+hexToBytes :: String -> Uint8Array
+hexToBytes = hexToBytesImpl


### PR DESCRIPTION
## Summary

- `MPFS.Crypto.Hash` — FFI module wrapping `@noble/hashes` for `blake2b256`, `bytesToHex`, `hexToBytes`
- Added `@noble/hashes` npm dependency (audited, zero deps)
- Added `arraybuffer-types` spago dependency

Closes #7