### PR TITLE
Port mpfs-spa client into Halogen browser

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,24 +6,189 @@
     <title>MPFS Explorer</title>
     <style>
         :root {
-            --bg: #1a1b26;
-            --fg: #c0caf5;
-            --accent: #7aa2f7;
-            --surface: #24283b;
-            --border: #3b4261;
-            --green: #9ece6a;
-            --yellow: #e0af68;
-            --red: #f7768e;
+            --bg: #f5f2eb;
+            --fg: #1f2933;
+            --muted: #65717c;
+            --surface: #fffdf8;
+            --surface-2: #ece7dd;
+            --border: #cfc7ba;
+            --accent: #0f766e;
+            --accent-2: #8f3d5f;
+            --disabled: #8a8f95;
         }
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
             background: var(--bg);
             color: var(--fg);
-            line-height: 1.6;
+            line-height: 1.5;
         }
-        #app { max-width: 1200px; margin: 0 auto; padding: 2rem; }
-        h1 { color: var(--accent); margin-bottom: 0.5rem; }
+        button { font: inherit; }
+        #app { min-height: 100vh; }
+        .app-shell {
+            width: min(1120px, calc(100vw - 32px));
+            margin: 0 auto;
+            padding: 28px 0;
+        }
+        .shell-header {
+            display: flex;
+            align-items: flex-end;
+            justify-content: space-between;
+            gap: 24px;
+            padding-bottom: 18px;
+            border-bottom: 1px solid var(--border);
+        }
+        .eyebrow {
+            color: var(--accent-2);
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0;
+            text-transform: uppercase;
+        }
+        h1 {
+            color: var(--fg);
+            font-size: clamp(1.8rem, 3vw, 2.7rem);
+            line-height: 1.1;
+            margin-top: 4px;
+        }
+        .status-row {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+            gap: 8px;
+        }
+        .status-pill {
+            min-width: 132px;
+            border: 1px solid var(--border);
+            background: var(--surface);
+            padding: 8px 10px;
+            border-radius: 6px;
+        }
+        .status-pill span,
+        .field-line span {
+            display: block;
+            color: var(--muted);
+            font-size: 0.76rem;
+            font-weight: 700;
+            letter-spacing: 0;
+            text-transform: uppercase;
+        }
+        .status-pill strong,
+        .field-line strong {
+            display: block;
+            color: var(--fg);
+            font-size: 0.95rem;
+            overflow-wrap: anywhere;
+        }
+        .tab-strip {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 8px;
+            margin: 18px 0;
+        }
+        .tab-button {
+            min-height: 44px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--surface);
+            color: var(--fg);
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            font-weight: 700;
+        }
+        .tab-button:hover {
+            border-color: var(--accent);
+        }
+        .tab-button.is-active {
+            background: #e0f2ef;
+            border-color: var(--accent);
+            color: #063f3b;
+        }
+        .tab-marker {
+            width: 8px;
+            height: 8px;
+            border-radius: 999px;
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+        }
+        .tab-button.is-active .tab-marker {
+            background: var(--accent);
+            border-color: var(--accent);
+        }
+        .panel {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-height: 360px;
+            padding: 22px;
+        }
+        .panel-layout {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 14px;
+        }
+        .panel-heading {
+            grid-column: 1 / -1;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border);
+        }
+        .panel-heading h2 {
+            font-size: 1.35rem;
+            line-height: 1.2;
+        }
+        .panel-heading p {
+            color: var(--muted);
+            margin-top: 4px;
+        }
+        .field-line {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: #faf8f2;
+            min-height: 74px;
+            padding: 12px;
+        }
+        .control-row {
+            grid-column: 1 / -1;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            padding-top: 8px;
+        }
+        .inert-button {
+            min-height: 40px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--surface-2);
+            color: var(--disabled);
+            padding: 0 14px;
+            cursor: not-allowed;
+        }
+        @media (max-width: 720px) {
+            .app-shell {
+                width: min(100vw - 20px, 1120px);
+                padding: 16px 0;
+            }
+            .shell-header {
+                align-items: stretch;
+                flex-direction: column;
+            }
+            .status-row {
+                justify-content: flex-start;
+            }
+            .status-pill {
+                flex: 1 1 148px;
+            }
+            .tab-strip,
+            .panel-layout {
+                grid-template-columns: 1fr;
+            }
+            .panel {
+                padding: 16px;
+            }
+        }
     </style>
 </head>
 <body>

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+rm -f src/assets/*.wasm
+echo "== lint =="; nix develop --quiet --command just lint
+echo "== ci (build + bundle + unit) =="; nix develop --quiet --command just ci
+echo "== e2e =="
+bp=$(nix build --no-link --print-out-paths .#cage-blueprint)
+gd=$(nix build --no-link --print-out-paths .#devnet-genesis)
+E2E_GENESIS_DIR="$gd" nix develop --quiet --command just e2e "$bp"
+echo "GATE GREEN ($(date -Is))"

--- a/spago.lock
+++ b/spago.lock
@@ -25,6 +25,7 @@
             "node-buffer",
             "node-child-process",
             "node-process",
+            "nullable",
             "ordered-collections",
             "prelude",
             "st",

--- a/spago.yaml
+++ b/spago.yaml
@@ -14,6 +14,7 @@ package:
     - bifunctors
     - either
     - maybe
+    - nullable
     - arrays
     - strings
     - web-html

--- a/specs/32-port-mpfs-spa/plan.md
+++ b/specs/32-port-mpfs-spa/plan.md
@@ -1,0 +1,136 @@
+# Plan
+
+## Scope
+
+Port the mature `mpfs-spa` feature set into the existing Halogen browser in six
+ordered, bisect-safe implementation slices. The orchestrator owns this plan and
+the PR metadata. Driver/navigator pairs own production and test code in each
+slice.
+
+## Source Map
+
+- Existing browser foundation:
+  - `src/App.purs`, `src/Main.purs`, `src/bootstrap.js`
+  - `src/MPFS/Client.purs`, `src/MPFS/Client/Types.purs`
+  - `src/MPFS/Reactor.purs`, `src/MPFS/Reactor.js`
+  - existing PureScript specs under `test/Test/MPFS/`
+- Mature source reference, read-only:
+  - `/code/cardano-mpfs-offchain/mpfs-spa/src/MpfsSpa/CageHelpers*`
+  - `/code/cardano-mpfs-offchain/mpfs-spa/src/MpfsSpa/Wallet/Cip30*`
+  - `/code/cardano-mpfs-offchain/mpfs-spa/src/MpfsSpa/Http.purs`
+  - `/code/cardano-mpfs-offchain/mpfs-spa/src/MpfsSpa/Submit.purs`
+  - `/code/cardano-mpfs-offchain/mpfs-spa/src/MpfsSpa/Tab/*`
+  - `/code/cardano-mpfs-offchain/mpfs-spa/src/MpfsSpa/App.purs`
+
+## Architectural Decisions
+
+- UI is rebuilt in Halogen. React/MUI modules are reference behavior only.
+- Protocol logic stays in the WASM reactors. PureScript builds JSON envelopes,
+  calls reactor FFI, parses stable one-line reactor verdicts, and renders
+  results.
+- The existing browser `MPFS.Client` remains the HTTP boundary. Slice 1 may
+  extend its wire types and endpoints where the port requires the mature SPA's
+  server calls.
+- The existing `MPFS.Reactor` verify wiring remains the verify path. The cage
+  transaction-building reactor is added as a separate boundary where useful,
+  while avoiding duplicated WASI runner code when the existing bridge can be
+  generalized safely inside the slice.
+- Runtime npm budget remains the Halogen budget: only `@bjorn3/browser_wasi_shim`
+  unless an explicitly reviewed slice widens it. PureScript package declarations
+  may be added when a slice's typed modules require them, but registry bumps,
+  npm additions, lockfile churn unrelated to the declared PureScript deps, and
+  flake input revisions require a Q-file to the epic.
+
+## Slice 1 - Logic Libraries and Cage Reactor Boundary
+
+Port the framework-agnostic domain layer needed by later UI slices:
+
+- shared domain types for wallet address, token id, key, value, request id,
+  unsigned transaction, trusted root, cage config, and cage error
+- cage helper record and WASM-backed implementation
+- cage reactor parsers for decode/cage transaction/sign assembly outputs
+- CIP-30 wallet FFI module
+- HTTP client extensions needed by the mature port, reconciled into
+  `MPFS.Client` instead of duplicating a second client
+- focused tests for write envelope construction and reactor output parsing
+
+This slice intentionally does not replace the placeholder UI.
+
+## Slice 2 - Halogen App Shell and Tab Routing
+
+Replace the placeholder `App.purs` with a real Halogen application shell:
+
+- top-level state for selected tab, selected token, base URL/client, remote data,
+  and connected wallet placeholder state
+- Connect, Tokens, Facts, and End tab navigation
+- empty but real tab panels with accessible controls and deterministic labels
+- CSS/static shell changes needed for a usable app surface
+- smoke or component-level proof that the app renders and tab navigation changes
+  panels
+
+No read/write behavior beyond the tab shell lands in this slice.
+
+## Slice 3 - Tokens Tab Read Path
+
+Implement the Tokens tab:
+
+- load and refresh token ids through `MPFS.Client.getTokens`
+- select a token and publish the selection to app state
+- show loading, empty, error, and success states
+- preserve #36 decoder behavior and add/extend focused tests where practical
+- provide a disabled or placeholder registration control only when it is not yet
+  wired to the write flow
+
+## Slice 4 - Facts Tab Read and Verification Path
+
+Implement the Facts tab read workflow:
+
+- load facts, token state, pending requests, and fact lookup for the selected
+  token through the client
+- render request phase/status data ported from the mature SPA behavior
+- route proof-bearing verification through the WASM verify reactor and surface
+  verified/error state in the UI
+- cover decoding/phase/verification helpers with focused tests
+
+Write buttons remain inert or unavailable until Slice 6.
+
+## Slice 5 - Connect Tab and Wallet State
+
+Implement the Connect tab:
+
+- discover available CIP-30 wallets
+- enable a wallet, read network/address/balance/change address, and refresh on
+  wallet events where the wallet API supports it
+- reject unsupported network state with clear UI feedback
+- expose connected wallet state to later write flows
+- test pure helpers such as owner key hash extraction and network labelling;
+  use FFI fakes where practical for wallet flow smoke
+
+## Slice 6 - Write Flow and End Tab
+
+Complete parity write behavior:
+
+- wire register token, insert/update/delete facts, retract request,
+  reject expired, update token, and end cage actions
+- build unsigned transactions through the cage reactor helper layer
+- sign with CIP-30, assemble witness sets through the reactor, submit via the
+  MPFS server, and display operation status
+- refresh relevant token/fact/request views after submit
+- implement End tab owner/destructive-action UX
+- add focused tests for submit state transitions and a gate-level e2e smoke
+
+## Verification
+
+Each slice uses a focused RED/GREEN command chosen by the driver from the
+available PureScript test surface, followed by `./gate.sh`. The orchestrator
+reruns `./gate.sh` before accepting each slice.
+
+## Forbidden Scope For All Slices
+
+- No edits in `/code/cardano-mpfs-offchain`.
+- No react-basic, MUI, Emotion, or `@noble/hashes` additions.
+- No npm dependency additions, flake input revisions, or PureScript registry
+  bumps unless a slice writes a Q-file and the epic explicitly approves the
+  scope expansion.
+- No replacing Haskell/WASM verification or transaction-building with JS
+  protocol logic.

--- a/specs/32-port-mpfs-spa/spec.md
+++ b/specs/32-port-mpfs-spa/spec.md
@@ -1,0 +1,63 @@
+# Issue #32: Port `mpfs-spa` Into the Halogen Browser
+
+## User Story
+
+As an MPFS user, I can use `cardano-mpfs-browser` as the canonical MPFS web
+client: connect a CIP-30 wallet, browse tokens and facts, verify proof-bearing
+read data through the WASM reactor, and build/sign/submit MPFS write
+transactions at parity with the mature `mpfs-spa` client.
+
+## Context
+
+`cardano-mpfs-browser` has the target architecture: PureScript, Halogen, a small
+npm runtime surface, and the WASM-Haskell verify foundation from #31. Its app UI
+is currently a placeholder.
+
+`cardano-mpfs-offchain/mpfs-spa` has the mature feature set: Connect, Facts,
+Tokens, and End screens; CIP-30 wallet integration; read paths; write envelope
+construction through the cage reactor; wallet signing; transaction assembly; and
+submit. That app uses react-basic and MUI, so its UI is reference behavior only.
+The port must rebuild the interface in Halogen and keep protocol/crypto work in
+the Haskell WASM reactors.
+
+## Functional Requirements
+
+- FR-001: The browser exposes Connect, Tokens, Facts, and End tabs in Halogen.
+- FR-002: Tokens are read with the existing `MPFS.Client` API, including the
+  bumped `/tokens` decoder from #36.
+- FR-003: Facts and pending requests for a selected token are readable from the
+  MPFS server and displayed with explicit loading, empty, error, and success
+  states.
+- FR-004: Proof-bearing read paths that need validation route verification
+  through the existing WASM verify reactor rather than through PureScript or JS
+  protocol logic.
+- FR-005: CIP-30 wallets can be discovered, enabled, refreshed, and used for
+  addresses, network, balance, signing, and submit.
+- FR-006: Write flows are built through the cage reactor for
+  `registerToken`, `insertFact`, `updateFact`, `deleteFact`, `retractRequest`,
+  `rejectExpired`, `endCage`, and `updateToken`.
+- FR-007: The write flow signs the unsigned transaction with the connected
+  wallet, assembles the witness set through the reactor, submits the signed
+  transaction, and displays the resulting status or failure.
+- FR-008: The shipped browser contains no react-basic UI, MUI, Emotion, or
+  `@noble/hashes` additions.
+
+## Non-Goals
+
+- Do not retire `mpfs-spa`; that is tracked by cardano-mpfs-offchain #372.
+- Do not implement the csmt-utxo second oracle; that belongs to #33.
+- Do not touch the offchain repository.
+- Do not replace Haskell/WASM protocol behavior with PureScript or JavaScript
+  protocol reimplementations.
+
+## Acceptance Criteria
+
+- Connect/Tokens/Facts/End tabs are present in the Halogen app shell.
+- Tokens and facts can be browsed against the same-revision devnet server used
+  by `./gate.sh`.
+- Wallet connect, address/network/balance display, signing, and submit are wired
+  through CIP-30.
+- Every MPFS write operation named in FR-006 uses the cage reactor boundary.
+- `./gate.sh` passes, including lint, CI, and e2e.
+- The final branch contains one bootstrap commit plus one bisect-safe commit per
+  implementation slice, each linked to `tasks.md` with a `Tasks:` trailer.

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -14,13 +14,13 @@
 
 ## Slice 2 - Halogen App Shell and Tab Routing
 
-- [ ] T032-S2 Replace the placeholder app with a Halogen shell containing
+- [X] T032-S2 Replace the placeholder app with a Halogen shell containing
   Connect, Tokens, Facts, and End navigation.
-- [ ] T032-S2 Add top-level app state for active tab, selected token, client
+- [X] T032-S2 Add top-level app state for active tab, selected token, client
   config, remote values, and wallet session state.
-- [ ] T032-S2 Add empty but real tab panels and static styling for a usable
+- [X] T032-S2 Add empty but real tab panels and static styling for a usable
   browser workbench.
-- [ ] T032-S2 Add focused render/navigation proof and run `./gate.sh`.
+- [X] T032-S2 Add focused render/navigation proof and run `./gate.sh`.
 
 ## Slice 3 - Tokens Tab Read Path
 

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -33,13 +33,13 @@
 
 ## Slice 4 - Facts Tab Read and Verification Path
 
-- [ ] T032-S4 Implement selected-token facts, token state, pending requests, and
+- [X] T032-S4 Implement selected-token facts, token state, pending requests, and
   fact lookup read flows.
-- [ ] T032-S4 Display request phase/status data and user-readable fact values
+- [X] T032-S4 Display request phase/status data and user-readable fact values
   based on the mature SPA behavior.
-- [ ] T032-S4 Route proof-bearing verification through the WASM verify reactor
+- [X] T032-S4 Route proof-bearing verification through the WASM verify reactor
   and render verified/error states.
-- [ ] T032-S4 Cover decoding, phase, and verification helpers with focused tests;
+- [X] T032-S4 Cover decoding, phase, and verification helpers with focused tests;
   run `./gate.sh`.
 
 ## Slice 5 - Connect Tab and Wallet State

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -65,5 +65,5 @@
 
 ## Orchestrator Finalization
 
-- [ ] T032-F1 Verify every slice commit, rerun `./gate.sh` at HEAD, update PR
+- [X] T032-F1 Verify every slice commit, rerun `./gate.sh` at HEAD, update PR
   metadata, and report `READY-FOR-REVIEW <sha>` to the epic orchestrator.

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -2,14 +2,14 @@
 
 ## Slice 1 - Logic Libraries and Cage Reactor Boundary
 
-- [ ] T032-S1 Add browser-native MPFS domain/cage types and helper records
+- [X] T032-S1 Add browser-native MPFS domain/cage types and helper records
   needed by the mature port.
-- [ ] T032-S1 Add cage reactor FFI/parsers for decode, transaction-build, and
+- [X] T032-S1 Add cage reactor FFI/parsers for decode, transaction-build, and
   signed-transaction assembly outputs while preserving the existing verify path.
-- [ ] T032-S1 Add CIP-30 wallet FFI wrappers and pure wallet display helpers.
-- [ ] T032-S1 Extend the existing `MPFS.Client` read/write HTTP boundary for
+- [X] T032-S1 Add CIP-30 wallet FFI wrappers and pure wallet display helpers.
+- [X] T032-S1 Extend the existing `MPFS.Client` read/write HTTP boundary for
   the endpoints needed by the port without duplicating a second client.
-- [ ] T032-S1 Add focused RED/GREEN tests for write envelope construction,
+- [X] T032-S1 Add focused RED/GREEN tests for write envelope construction,
   reactor output parsing, and pure wallet helpers; run `./gate.sh`.
 
 ## Slice 2 - Halogen App Shell and Tab Routing

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -1,0 +1,69 @@
+# Tasks
+
+## Slice 1 - Logic Libraries and Cage Reactor Boundary
+
+- [ ] T032-S1 Add browser-native MPFS domain/cage types and helper records
+  needed by the mature port.
+- [ ] T032-S1 Add cage reactor FFI/parsers for decode, transaction-build, and
+  signed-transaction assembly outputs while preserving the existing verify path.
+- [ ] T032-S1 Add CIP-30 wallet FFI wrappers and pure wallet display helpers.
+- [ ] T032-S1 Extend the existing `MPFS.Client` read/write HTTP boundary for
+  the endpoints needed by the port without duplicating a second client.
+- [ ] T032-S1 Add focused RED/GREEN tests for write envelope construction,
+  reactor output parsing, and pure wallet helpers; run `./gate.sh`.
+
+## Slice 2 - Halogen App Shell and Tab Routing
+
+- [ ] T032-S2 Replace the placeholder app with a Halogen shell containing
+  Connect, Tokens, Facts, and End navigation.
+- [ ] T032-S2 Add top-level app state for active tab, selected token, client
+  config, remote values, and wallet session state.
+- [ ] T032-S2 Add empty but real tab panels and static styling for a usable
+  browser workbench.
+- [ ] T032-S2 Add focused render/navigation proof and run `./gate.sh`.
+
+## Slice 3 - Tokens Tab Read Path
+
+- [ ] T032-S3 Implement token loading, refresh, empty/error/success states, and
+  token selection through `MPFS.Client.getTokens`.
+- [ ] T032-S3 Preserve the #36 bumped `/tokens` decoder behavior and add or
+  extend focused tests where needed.
+- [ ] T032-S3 Wire selected token state from the Tokens tab into the app shell.
+- [ ] T032-S3 Run the focused proof and `./gate.sh`.
+
+## Slice 4 - Facts Tab Read and Verification Path
+
+- [ ] T032-S4 Implement selected-token facts, token state, pending requests, and
+  fact lookup read flows.
+- [ ] T032-S4 Display request phase/status data and user-readable fact values
+  based on the mature SPA behavior.
+- [ ] T032-S4 Route proof-bearing verification through the WASM verify reactor
+  and render verified/error states.
+- [ ] T032-S4 Cover decoding, phase, and verification helpers with focused tests;
+  run `./gate.sh`.
+
+## Slice 5 - Connect Tab and Wallet State
+
+- [ ] T032-S5 Implement CIP-30 wallet discovery, enable, refresh, disconnect,
+  and connected wallet display.
+- [ ] T032-S5 Read network, used/change addresses, and balance; reject
+  unsupported networks with clear UI feedback.
+- [ ] T032-S5 Propagate wallet state to the app shell for later write actions.
+- [ ] T032-S5 Add focused pure/FFI-fake wallet tests where practical and run
+  `./gate.sh`.
+
+## Slice 6 - Write Flow and End Tab
+
+- [ ] T032-S6 Wire register token, insert/update/delete fact, retract request,
+  reject expired, update token, and end cage actions through the cage reactor.
+- [ ] T032-S6 Sign unsigned transactions with CIP-30, assemble witness sets
+  through the reactor, submit signed transactions, and display operation status.
+- [ ] T032-S6 Refresh affected token/fact/request views after submit and finish
+  the End tab owner/destructive-action workflow.
+- [ ] T032-S6 Add focused write-flow tests plus the required e2e proof; run
+  `./gate.sh`.
+
+## Orchestrator Finalization
+
+- [ ] T032-F1 Verify every slice commit, rerun `./gate.sh` at HEAD, update PR
+  metadata, and report `READY-FOR-REVIEW <sha>` to the epic orchestrator.

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -44,12 +44,12 @@
 
 ## Slice 5 - Connect Tab and Wallet State
 
-- [ ] T032-S5 Implement CIP-30 wallet discovery, enable, refresh, disconnect,
+- [X] T032-S5 Implement CIP-30 wallet discovery, enable, refresh, disconnect,
   and connected wallet display.
-- [ ] T032-S5 Read network, used/change addresses, and balance; reject
+- [X] T032-S5 Read network, used/change addresses, and balance; reject
   unsupported networks with clear UI feedback.
-- [ ] T032-S5 Propagate wallet state to the app shell for later write actions.
-- [ ] T032-S5 Add focused pure/FFI-fake wallet tests where practical and run
+- [X] T032-S5 Propagate wallet state to the app shell for later write actions.
+- [X] T032-S5 Add focused pure/FFI-fake wallet tests where practical and run
   `./gate.sh`.
 
 ## Slice 6 - Write Flow and End Tab

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -24,12 +24,12 @@
 
 ## Slice 3 - Tokens Tab Read Path
 
-- [ ] T032-S3 Implement token loading, refresh, empty/error/success states, and
+- [X] T032-S3 Implement token loading, refresh, empty/error/success states, and
   token selection through `MPFS.Client.getTokens`.
-- [ ] T032-S3 Preserve the #36 bumped `/tokens` decoder behavior and add or
+- [X] T032-S3 Preserve the #36 bumped `/tokens` decoder behavior and add or
   extend focused tests where needed.
-- [ ] T032-S3 Wire selected token state from the Tokens tab into the app shell.
-- [ ] T032-S3 Run the focused proof and `./gate.sh`.
+- [X] T032-S3 Wire selected token state from the Tokens tab into the app shell.
+- [X] T032-S3 Run the focused proof and `./gate.sh`.
 
 ## Slice 4 - Facts Tab Read and Verification Path
 

--- a/specs/32-port-mpfs-spa/tasks.md
+++ b/specs/32-port-mpfs-spa/tasks.md
@@ -54,13 +54,13 @@
 
 ## Slice 6 - Write Flow and End Tab
 
-- [ ] T032-S6 Wire register token, insert/update/delete fact, retract request,
+- [X] T032-S6 Wire register token, insert/update/delete fact, retract request,
   reject expired, update token, and end cage actions through the cage reactor.
-- [ ] T032-S6 Sign unsigned transactions with CIP-30, assemble witness sets
+- [X] T032-S6 Sign unsigned transactions with CIP-30, assemble witness sets
   through the reactor, submit signed transactions, and display operation status.
-- [ ] T032-S6 Refresh affected token/fact/request views after submit and finish
+- [X] T032-S6 Refresh affected token/fact/request views after submit and finish
   the End tab owner/destructive-action workflow.
-- [ ] T032-S6 Add focused write-flow tests plus the required e2e proof; run
+- [X] T032-S6 Add focused write-flow tests plus the required e2e proof; run
   `./gate.sh`.
 
 ## Orchestrator Finalization

--- a/src/App.purs
+++ b/src/App.purs
@@ -2,6 +2,7 @@ module App where
 
 import Prelude
 
+import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.DateTime.Instant as Instant
@@ -13,6 +14,7 @@ import Effect.Class (liftEffect)
 import Effect.Now as Now
 import Halogen as H
 import Halogen.Subscription as HS
+import MPFS.App.Config as AppConfig
 import MPFS.App.Facts as Facts
 import MPFS.App.State (AppState, WalletStatus(..), defaultState, selectTab)
 import MPFS.App.Tab (AppTab)
@@ -20,9 +22,22 @@ import MPFS.App.Tokens as Tokens
 import MPFS.App.Verification as Verification
 import MPFS.App.View as View
 import MPFS.App.Wallet as Wallet
+import MPFS.App.Write as Write
+import MPFS.App.Write (WriteStatus(..))
+import MPFS.Cage (CageResult)
+import MPFS.Cage.Wasm as CageWasm
 import MPFS.Client as Client
 import MPFS.Client.Types as ClientTypes
-import MPFS.Types (TokenId(..))
+import MPFS.Types
+  ( CageConfig
+  , Key(..)
+  , RequestId
+  , TokenId(..)
+  , UnsignedTxCbor(..)
+  , Value(..)
+  , WalletAddr(..)
+  , cageErrorMessage
+  )
 import MPFS.Wallet.Cip30 as Cip30
 
 data Action
@@ -35,6 +50,22 @@ data Action
   | LoadTokens
   | SelectToken TokenId
   | LoadFacts
+  | RegisterToken
+  | UpdateInsertKey String
+  | UpdateInsertValue String
+  | SubmitInsertFact
+  | UpdateUpdateKey String
+  | UpdateUpdateOldValue String
+  | UpdateUpdateNewValue String
+  | SubmitUpdateFact
+  | UpdateDeleteKey String
+  | UpdateDeleteValue String
+  | SubmitDeleteFact
+  | ToggleRequestSelection RequestId
+  | RetractRequest RequestId
+  | RejectExpired
+  | UpdateToken
+  | EndCage
   | UpdateFactLookupKey String
   | LookupFact
   | UpdateFactProofEnvelope String
@@ -54,6 +85,22 @@ component =
           , loadTokens: LoadTokens
           , selectToken: SelectToken
           , loadFacts: LoadFacts
+          , registerToken: RegisterToken
+          , updateInsertKey: UpdateInsertKey
+          , updateInsertValue: UpdateInsertValue
+          , submitInsertFact: SubmitInsertFact
+          , updateUpdateKey: UpdateUpdateKey
+          , updateUpdateOldValue: UpdateUpdateOldValue
+          , updateUpdateNewValue: UpdateUpdateNewValue
+          , submitUpdateFact: SubmitUpdateFact
+          , updateDeleteKey: UpdateDeleteKey
+          , updateDeleteValue: UpdateDeleteValue
+          , submitDeleteFact: SubmitDeleteFact
+          , toggleRequestSelection: ToggleRequestSelection
+          , retractRequest: RetractRequest
+          , rejectExpired: RejectExpired
+          , updateToken: UpdateToken
+          , endCage: EndCage
           , updateFactLookupKey: UpdateFactLookupKey
           , lookupFact: LookupFact
           , updateFactProofEnvelope: UpdateFactProofEnvelope
@@ -150,7 +197,8 @@ handleAction = case _ of
         H.modify_ (Tokens.finishTokenLoad (fromClientTokenIds tokenIds))
 
   SelectToken token ->
-    H.modify_ (Tokens.selectToken token)
+    H.modify_ \state ->
+      (Tokens.selectToken token state) { selectedRequestIds = [] }
 
   LoadFacts -> do
     state <- H.get
@@ -185,6 +233,120 @@ handleAction = case _ of
             H.modify_ (Facts.failFactsLoad (show error))
           _, _, _, Left error ->
             H.modify_ (Facts.failFactsLoad (show error))
+
+  RegisterToken ->
+    runWriteOperation Write.WriteRegisterToken \client address cfg _state ->
+      Right $ (CageWasm.wasmCageHelpers client).registerToken address cfg
+
+  UpdateInsertKey key ->
+    H.modify_ (Write.setInsertKey key)
+
+  UpdateInsertValue value ->
+    H.modify_ (Write.setInsertValue value)
+
+  SubmitInsertFact ->
+    runWriteOperation Write.WriteInsertFact \client address cfg state ->
+      withSelectedToken state \token ->
+        Right
+          ( (CageWasm.wasmCageHelpers client).insertFact
+              address
+              cfg
+              token
+              (Key state.writeForms.insertKey)
+              (Value state.writeForms.insertValue)
+          )
+
+  UpdateUpdateKey key ->
+    H.modify_ (Write.setUpdateKey key)
+
+  UpdateUpdateOldValue value ->
+    H.modify_ (Write.setUpdateOldValue value)
+
+  UpdateUpdateNewValue value ->
+    H.modify_ (Write.setUpdateNewValue value)
+
+  SubmitUpdateFact ->
+    runWriteOperation Write.WriteUpdateFact \client address cfg state ->
+      withSelectedToken state \token ->
+        Right
+          ( (CageWasm.wasmCageHelpers client).updateFact
+              address
+              cfg
+              token
+              (Key state.writeForms.updateKey)
+              (Value state.writeForms.updateOldValue)
+              (Value state.writeForms.updateNewValue)
+          )
+
+  UpdateDeleteKey key ->
+    H.modify_ (Write.setDeleteKey key)
+
+  UpdateDeleteValue value ->
+    H.modify_ (Write.setDeleteValue value)
+
+  SubmitDeleteFact ->
+    runWriteOperation Write.WriteDeleteFact \client address cfg state ->
+      withSelectedToken state \token ->
+        Right
+          ( (CageWasm.wasmCageHelpers client).deleteFact
+              address
+              cfg
+              token
+              (Key state.writeForms.deleteKey)
+              (Value state.writeForms.deleteValue)
+          )
+
+  ToggleRequestSelection requestId ->
+    H.modify_ (Write.toggleRequestSelection requestId)
+
+  RetractRequest requestId ->
+    runWriteOperation Write.WriteRetractRequest \client address cfg state ->
+      withSelectedToken state \token ->
+        Right
+          ( (CageWasm.wasmCageHelpers client).retractRequest
+              address
+              cfg
+              token
+              requestId
+          )
+
+  RejectExpired ->
+    runWriteOperation Write.WriteRejectExpired \client address cfg state ->
+      withSelectedToken state \token ->
+        if Array.null state.selectedRequestIds then
+          Left "Select at least one expired request."
+        else
+          Right
+            ( (CageWasm.wasmCageHelpers client).rejectExpired
+                address
+                cfg
+                token
+                state.selectedRequestIds
+            )
+
+  UpdateToken ->
+    runWriteOperation Write.WriteUpdateToken \client address cfg state ->
+      withSelectedToken state \token ->
+        if Array.null state.selectedRequestIds then
+          Left "Select at least one processable request."
+        else
+          Right
+            ( (CageWasm.wasmCageHelpers client).updateToken
+                address
+                cfg
+                token
+                state.selectedRequestIds
+            )
+
+  EndCage ->
+    runWriteOperation Write.WriteEndCage \client address cfg state ->
+      withSelectedToken state \token ->
+        Right
+          ( (CageWasm.wasmCageHelpers client).endCage
+              address
+              cfg
+              token
+          )
 
   UpdateFactLookupKey key ->
     H.modify_ (Facts.setFactLookupKey key)
@@ -269,3 +431,108 @@ subscribeWalletChanges
 subscribeWalletChanges api =
   H.subscribe $ HS.makeEmitter \push -> do
     Cip30.subscribeAccountChanges api (push RefreshWallet)
+
+type BuildWrite =
+  Client.Client
+  -> WalletAddr
+  -> CageConfig
+  -> AppState
+  -> Either String CageResult
+
+runWriteOperation
+  :: forall slots output m
+   . MonadAff m
+  => Write.WriteOperation
+  -> BuildWrite
+  -> H.HalogenM AppState Action slots output m Unit
+runWriteOperation operation buildWrite = do
+  state <- H.get
+  case Write.validatePrerequisites operation state of
+    Left message ->
+      H.modify_ (Write.failWrite message)
+    Right _ ->
+      case state.walletSession.api, state.walletSession.selectedAddress of
+        Just api, Just address ->
+          case
+            buildWrite
+              (Client.mkClient state.baseUrl)
+              (WalletAddr address)
+              AppConfig.defaultCageConfig
+              state
+            of
+            Left message ->
+              H.modify_ (Write.failWrite message)
+            Right build ->
+              runWritePipeline operation api (Client.mkClient state.baseUrl) build
+        _, _ ->
+          H.modify_ (Write.failWrite "Connect a wallet first.")
+
+runWritePipeline
+  :: forall slots output m
+   . MonadAff m
+  => Write.WriteOperation
+  -> Cip30.WalletApi
+  -> Client.Client
+  -> CageResult
+  -> H.HalogenM AppState Action slots output m Unit
+runWritePipeline operation api client build = do
+  initial <- H.get
+  H.modify_ _ { writeStatus = WriteBuilding }
+  built <- liftAff build
+  case built of
+    Left err ->
+      H.modify_ (Write.failWrite (cageErrorMessage err))
+    Right unsigned@(UnsignedTxCbor unsignedHex) -> do
+      H.modify_ _ { writeStatus = WriteBuilt unsigned }
+      H.modify_ _ { writeStatus = WriteSigning unsigned }
+      signed <- liftAff $ attempt (Cip30.signTx api unsignedHex true)
+      case signed of
+        Left _ ->
+          H.modify_ (Write.failWrite "Wallet signing failed or was declined.")
+        Right witnessSet -> do
+          H.modify_ _ { writeStatus = WriteAssembling unsigned witnessSet }
+          assembled <- liftAff (CageWasm.assembleTx unsignedHex witnessSet)
+          case assembled of
+            Left err ->
+              H.modify_ (Write.failWrite (cageErrorMessage err))
+            Right signedTx -> do
+              H.modify_ _ { writeStatus = WriteSubmitting unsigned witnessSet signedTx }
+              submitted <- liftAff (client.submitSignedTx signedTx)
+              case submitted of
+                Left error ->
+                  H.modify_ (Write.failWrite (show error))
+                Right txId -> do
+                  let
+                    keepToken =
+                      case operation of
+                        Write.WriteEndCage -> Nothing
+                        _ -> initial.selectedToken
+                  H.modify_ \current ->
+                    current
+                      { writeStatus =
+                          Write.submittedWrite unsigned witnessSet signedTx txId
+                      , selectedToken = keepToken
+                      , selectedRequestIds = []
+                      }
+                  refreshAfterSubmit keepToken
+
+refreshAfterSubmit
+  :: forall slots output m
+   . MonadAff m
+  => Maybe TokenId
+  -> H.HalogenM AppState Action slots output m Unit
+refreshAfterSubmit mToken = do
+  handleAction LoadTokens
+  case mToken of
+    Nothing ->
+      pure unit
+    Just _ ->
+      handleAction LoadFacts
+
+withSelectedToken
+  :: AppState
+  -> (TokenId -> Either String CageResult)
+  -> Either String CageResult
+withSelectedToken state f = case state.selectedToken of
+  Nothing -> Left "Select a token first."
+  Just token -> f token

--- a/src/App.purs
+++ b/src/App.purs
@@ -3,24 +3,24 @@ module App where
 import Prelude
 
 import Halogen as H
-import Halogen.HTML as HH
+import MPFS.App.State (AppState, defaultState, selectTab)
+import MPFS.App.Tab (AppTab)
+import MPFS.App.View as View
 
-type State = {}
+data Action = SelectTab AppTab
 
 component :: forall q i o m. H.Component q i o m
 component =
   H.mkComponent
-    { initialState: const {}
-    , render
-    , eval: H.mkEval H.defaultEval
+    { initialState: const defaultState
+    , render: View.render SelectTab
+    , eval: H.mkEval H.defaultEval { handleAction = handleAction }
     }
 
-render :: forall m. State -> H.ComponentHTML Void () m
-render _ =
-  HH.div_
-    [ HH.h1_ [ HH.text "MPFS Explorer" ]
-    , HH.p_
-        [ HH.text
-            "Fact explorer and transaction verifier"
-        ]
-    ]
+handleAction
+  :: forall slots output m
+   . Action
+  -> H.HalogenM AppState Action slots output m Unit
+handleAction = case _ of
+  SelectTab tab ->
+    H.modify_ (selectTab tab)

--- a/src/App.purs
+++ b/src/App.purs
@@ -6,22 +6,32 @@ import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.DateTime.Instant as Instant
 import Data.Time.Duration (Milliseconds(..))
+import Data.Traversable (traverse_)
+import Effect.Aff (Aff, attempt)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (liftEffect)
 import Effect.Now as Now
 import Halogen as H
+import Halogen.Subscription as HS
 import MPFS.App.Facts as Facts
-import MPFS.App.State (AppState, defaultState, selectTab)
+import MPFS.App.State (AppState, WalletStatus(..), defaultState, selectTab)
 import MPFS.App.Tab (AppTab)
 import MPFS.App.Tokens as Tokens
 import MPFS.App.Verification as Verification
 import MPFS.App.View as View
+import MPFS.App.Wallet as Wallet
 import MPFS.Client as Client
 import MPFS.Client.Types as ClientTypes
 import MPFS.Types (TokenId(..))
+import MPFS.Wallet.Cip30 as Cip30
 
 data Action
-  = SelectTab AppTab
+  = Initialize
+  | SelectTab AppTab
+  | LoadWallets
+  | ConnectWallet Cip30.WalletInfo
+  | RefreshWallet
+  | DisconnectWallet
   | LoadTokens
   | SelectToken TokenId
   | LoadFacts
@@ -37,6 +47,10 @@ component =
     , render:
         View.render
           { selectTab: SelectTab
+          , loadWallets: LoadWallets
+          , connectWallet: ConnectWallet
+          , refreshWallet: RefreshWallet
+          , disconnectWallet: DisconnectWallet
           , loadTokens: LoadTokens
           , selectToken: SelectToken
           , loadFacts: LoadFacts
@@ -45,7 +59,11 @@ component =
           , updateFactProofEnvelope: UpdateFactProofEnvelope
           , verifyFactEnvelope: VerifyFactEnvelope
           }
-    , eval: H.mkEval H.defaultEval { handleAction = handleAction }
+    , eval:
+        H.mkEval H.defaultEval
+          { initialize = Just Initialize
+          , handleAction = handleAction
+          }
     }
 
 handleAction
@@ -54,8 +72,73 @@ handleAction
   => Action
   -> H.HalogenM AppState Action slots output m Unit
 handleAction = case _ of
+  Initialize ->
+    loadWallets
+
   SelectTab tab ->
     H.modify_ (selectTab tab)
+
+  LoadWallets ->
+    loadWallets
+
+  ConnectWallet info -> do
+    state <- H.get
+    traverse_ H.unsubscribe state.walletSession.subscriptionId
+    H.modify_ (Wallet.startWalletConnection info)
+    result <- liftAff $ attempt do
+      api <- Cip30.enable info.key
+      details <- readWalletDetails api
+      pure { api, details }
+    case result of
+      Left _ ->
+        H.modify_
+          ( Wallet.failWalletConnection
+              "Wallet connection failed or was declined."
+          )
+      Right { api, details } -> do
+        H.modify_ (Wallet.finishWalletConnection info details)
+        connected <- H.get
+        case connected.walletSession.status of
+          WalletConnected -> do
+            subscriptionId <- subscribeWalletChanges api
+            H.modify_
+              (Wallet.setWalletRuntime (Just api) (Just subscriptionId))
+          _ ->
+            pure unit
+
+  RefreshWallet -> do
+    state <- H.get
+    case state.walletSession.api of
+      Nothing ->
+        H.modify_ (Wallet.failWalletConnection "Connect a wallet first.")
+      Just api -> do
+        result <- liftAff $ attempt (readWalletDetails api)
+        case result of
+          Left _ ->
+            H.modify_
+              \current ->
+                current
+                  { walletSession =
+                      current.walletSession
+                        { feedback = Just "Wallet account refresh failed." }
+                  }
+          Right details -> do
+            H.modify_ (Wallet.finishWalletRefresh details)
+            refreshed <- H.get
+            case refreshed.walletSession.status of
+              WalletConnected ->
+                H.modify_
+                  ( Wallet.setWalletRuntime
+                      (Just api)
+                      refreshed.walletSession.subscriptionId
+                  )
+              _ ->
+                traverse_ H.unsubscribe state.walletSession.subscriptionId
+
+  DisconnectWallet -> do
+    state <- H.get
+    traverse_ H.unsubscribe state.walletSession.subscriptionId
+    H.modify_ Wallet.disconnectWallet
 
   LoadTokens -> do
     state <- H.modify Tokens.startTokenLoad
@@ -155,3 +238,34 @@ currentTimeMillis = do
   let
     Milliseconds millis = Instant.unInstant instant
   pure millis
+
+loadWallets
+  :: forall slots output m
+   . MonadAff m
+  => H.HalogenM AppState Action slots output m Unit
+loadWallets = do
+  H.modify_ Wallet.startWalletDiscovery
+  wallets <- liftEffect Cip30.availableWallets
+  H.modify_ (Wallet.finishWalletDiscovery wallets)
+
+readWalletDetails :: Cip30.WalletApi -> Aff Wallet.ConnectedWalletDetails
+readWalletDetails api = do
+  networkId <- Cip30.getNetworkId api
+  usedAddresses <- Cip30.getUsedAddresses api
+  changeAddress <- Cip30.getChangeAddress api
+  balance <- Cip30.getBalance api
+  pure
+    { networkId
+    , usedAddresses
+    , changeAddress
+    , lovelace: Cip30.lovelaceOfBalance balance
+    }
+
+subscribeWalletChanges
+  :: forall slots output m
+   . MonadAff m
+  => Cip30.WalletApi
+  -> H.HalogenM AppState Action slots output m H.SubscriptionId
+subscribeWalletChanges api =
+  H.subscribe $ HS.makeEmitter \push -> do
+    Cip30.subscribeAccountChanges api (push RefreshWallet)

--- a/src/App.purs
+++ b/src/App.purs
@@ -3,20 +3,32 @@ module App where
 import Prelude
 
 import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.DateTime.Instant as Instant
+import Data.Time.Duration (Milliseconds(..))
 import Effect.Aff.Class (class MonadAff, liftAff)
+import Effect.Class (liftEffect)
+import Effect.Now as Now
 import Halogen as H
-import MPFS.App.Tokens as Tokens
+import MPFS.App.Facts as Facts
 import MPFS.App.State (AppState, defaultState, selectTab)
 import MPFS.App.Tab (AppTab)
+import MPFS.App.Tokens as Tokens
+import MPFS.App.Verification as Verification
+import MPFS.App.View as View
 import MPFS.Client as Client
 import MPFS.Client.Types as ClientTypes
 import MPFS.Types (TokenId(..))
-import MPFS.App.View as View
 
 data Action
   = SelectTab AppTab
   | LoadTokens
   | SelectToken TokenId
+  | LoadFacts
+  | UpdateFactLookupKey String
+  | LookupFact
+  | UpdateFactProofEnvelope String
+  | VerifyFactEnvelope
 
 component :: forall q i o m. MonadAff m => H.Component q i o m
 component =
@@ -27,6 +39,11 @@ component =
           { selectTab: SelectTab
           , loadTokens: LoadTokens
           , selectToken: SelectToken
+          , loadFacts: LoadFacts
+          , updateFactLookupKey: UpdateFactLookupKey
+          , lookupFact: LookupFact
+          , updateFactProofEnvelope: UpdateFactProofEnvelope
+          , verifyFactEnvelope: VerifyFactEnvelope
           }
     , eval: H.mkEval H.defaultEval { handleAction = handleAction }
     }
@@ -52,5 +69,89 @@ handleAction = case _ of
   SelectToken token ->
     H.modify_ (Tokens.selectToken token)
 
+  LoadFacts -> do
+    state <- H.get
+    case state.selectedToken of
+      Nothing ->
+        H.modify_ (Facts.failFactsLoad "Select a token first.")
+      Just token -> do
+        loadingState <- H.modify Facts.startFactsLoad
+        let
+          client = Client.mkClient loadingState.baseUrl
+          clientToken = fromAppTokenId token
+        tokenStateResult <- liftAff (client.getToken clientToken)
+        requestsResult <- liftAff (client.getTokenRequests clientToken)
+        factsResult <- liftAff (client.getTokenFacts clientToken)
+        trustedRootResult <- liftAff client.getTrustedRoot
+        case tokenStateResult, requestsResult, factsResult, trustedRootResult of
+          Right tokenState, Right requests, Right facts, Right trustedRoot -> do
+            requestNowMillis <- currentTimeMillis
+            H.modify_
+              ( Facts.finishFactsLoadWithRootAt
+                  requestNowMillis
+                  tokenState
+                  requests
+                  facts
+                  trustedRoot
+              )
+          Left error, _, _, _ ->
+            H.modify_ (Facts.failFactsLoad (show error))
+          _, Left error, _, _ ->
+            H.modify_ (Facts.failFactsLoad (show error))
+          _, _, Left error, _ ->
+            H.modify_ (Facts.failFactsLoad (show error))
+          _, _, _, Left error ->
+            H.modify_ (Facts.failFactsLoad (show error))
+
+  UpdateFactLookupKey key ->
+    H.modify_ (Facts.setFactLookupKey key)
+
+  LookupFact -> do
+    state <- H.get
+    case state.selectedToken of
+      Nothing ->
+        H.modify_ (Facts.failFactLookup "Select a token first.")
+      Just _ | state.factLookup.key == "" ->
+        H.modify_ (Facts.failFactLookup "Enter a fact key.")
+      Just token -> do
+        H.modify_ (Facts.startFactLookup state.factLookup.key)
+        result <-
+          liftAff
+            ( (Client.mkClient state.baseUrl).getTokenFact
+                (fromAppTokenId token)
+                state.factLookup.key
+            )
+        case result of
+          Left error ->
+            H.modify_ (Facts.failFactLookup (show error))
+          Right value ->
+            H.modify_ (Facts.finishFactLookup value)
+
+  UpdateFactProofEnvelope envelope ->
+    H.modify_ (Facts.setFactProofEnvelope envelope)
+
+  VerifyFactEnvelope -> do
+    state <- H.get
+    if state.factLookup.proofEnvelope == "" then
+      H.modify_
+        ( Verification.finishVerification
+            (Left "Enter a proof envelope.")
+        )
+    else do
+      H.modify_ Verification.startVerification
+      result <- liftAff
+        (Verification.verifyFactEnvelope state.factLookup.proofEnvelope)
+      H.modify_ (Verification.finishVerification result)
+
 fromClientTokenIds :: Array ClientTypes.TokenId -> Array TokenId
 fromClientTokenIds = map TokenId
+
+fromAppTokenId :: TokenId -> ClientTypes.TokenId
+fromAppTokenId (TokenId tokenId) = tokenId
+
+currentTimeMillis :: forall m. MonadAff m => m Number
+currentTimeMillis = do
+  instant <- liftEffect Now.now
+  let
+    Milliseconds millis = Instant.unInstant instant
+  pure millis

--- a/src/App.purs
+++ b/src/App.purs
@@ -2,25 +2,55 @@ module App where
 
 import Prelude
 
+import Data.Either (Either(..))
+import Effect.Aff.Class (class MonadAff, liftAff)
 import Halogen as H
+import MPFS.App.Tokens as Tokens
 import MPFS.App.State (AppState, defaultState, selectTab)
 import MPFS.App.Tab (AppTab)
+import MPFS.Client as Client
+import MPFS.Client.Types as ClientTypes
+import MPFS.Types (TokenId(..))
 import MPFS.App.View as View
 
-data Action = SelectTab AppTab
+data Action
+  = SelectTab AppTab
+  | LoadTokens
+  | SelectToken TokenId
 
-component :: forall q i o m. H.Component q i o m
+component :: forall q i o m. MonadAff m => H.Component q i o m
 component =
   H.mkComponent
     { initialState: const defaultState
-    , render: View.render SelectTab
+    , render:
+        View.render
+          { selectTab: SelectTab
+          , loadTokens: LoadTokens
+          , selectToken: SelectToken
+          }
     , eval: H.mkEval H.defaultEval { handleAction = handleAction }
     }
 
 handleAction
   :: forall slots output m
-   . Action
+   . MonadAff m
+  => Action
   -> H.HalogenM AppState Action slots output m Unit
 handleAction = case _ of
   SelectTab tab ->
     H.modify_ (selectTab tab)
+
+  LoadTokens -> do
+    state <- H.modify Tokens.startTokenLoad
+    result <- liftAff (Client.mkClient state.baseUrl).getTokens
+    case result of
+      Left error ->
+        H.modify_ (Tokens.failTokenLoad (show error))
+      Right tokenIds ->
+        H.modify_ (Tokens.finishTokenLoad (fromClientTokenIds tokenIds))
+
+  SelectToken token ->
+    H.modify_ (Tokens.selectToken token)
+
+fromClientTokenIds :: Array ClientTypes.TokenId -> Array TokenId
+fromClientTokenIds = map TokenId

--- a/src/MPFS/App/Config.purs
+++ b/src/MPFS/App/Config.purs
@@ -1,0 +1,20 @@
+module MPFS.App.Config
+  ( defaultCageConfig
+  , preprodCageConfig
+  ) where
+
+import MPFS.Types (CageConfig)
+
+defaultCageConfig :: CageConfig
+defaultCageConfig = preprodCageConfig
+
+preprodCageConfig :: CageConfig
+preprodCageConfig =
+  { cageScriptBytes: "__MPFS_CAGE_SCRIPT_BYTES__"
+  , requestScriptBytes: "__MPFS_REQUEST_SCRIPT_BYTES__"
+  , cfgScriptHash: "__MPFS_CAGE_SCRIPT_HASH__"
+  , defaultProcessTime: 1800000
+  , defaultRetractTime: 1800000
+  , defaultTip: 2000000
+  , network: "preprod"
+  }

--- a/src/MPFS/App/Facts.purs
+++ b/src/MPFS/App/Facts.purs
@@ -1,0 +1,160 @@
+module MPFS.App.Facts
+  ( RequestPhase(..)
+  , failFactLookup
+  , failFactsLoad
+  , finishFactLookup
+  , finishFactsLoad
+  , finishFactsLoadAt
+  , finishFactsLoadWithRootAt
+  , phaseLabel
+  , requestPhase
+  , setFactLookupKey
+  , setFactProofEnvelope
+  , startFactLookup
+  , startFactsLoad
+  ) where
+
+import Prelude
+
+import MPFS.App.State (AppState)
+import MPFS.App.Verification (VerificationStatus(..))
+import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
+import MPFS.Types (TrustedRoot)
+import MPFS.UI.Remote (Remote(..))
+
+data RequestPhase
+  = PhaseProcessable
+  | PhaseRetractable
+  | PhaseExpired
+
+derive instance Eq RequestPhase
+
+instance Show RequestPhase where
+  show = case _ of
+    PhaseProcessable -> "PhaseProcessable"
+    PhaseRetractable -> "PhaseRetractable"
+    PhaseExpired -> "PhaseExpired"
+
+startFactsLoad :: AppState -> AppState
+startFactsLoad state =
+  state
+    { facts = Loading
+    , tokenState = Loading
+    , pendingRequests = Loading
+    , trustedRoot = Loading
+    }
+
+finishFactsLoad
+  :: TokenState
+  -> Array PendingRequest
+  -> Array FactEntry
+  -> AppState
+  -> AppState
+finishFactsLoad =
+  finishFactsLoadAt 0.0
+
+finishFactsLoadAt
+  :: Number
+  -> TokenState
+  -> Array PendingRequest
+  -> Array FactEntry
+  -> AppState
+  -> AppState
+finishFactsLoadAt nowMillis tokenState requests facts state =
+  state
+    { tokenState = Success tokenState
+    , pendingRequests = Success requests
+    , facts = Success facts
+    , requestNowMillis = nowMillis
+    }
+
+finishFactsLoadWithRootAt
+  :: Number
+  -> TokenState
+  -> Array PendingRequest
+  -> Array FactEntry
+  -> TrustedRoot
+  -> AppState
+  -> AppState
+finishFactsLoadWithRootAt nowMillis tokenState requests facts trustedRoot state =
+  (finishFactsLoadAt nowMillis tokenState requests facts state)
+    { trustedRoot = Success trustedRoot }
+
+failFactsLoad :: String -> AppState -> AppState
+failFactsLoad message state =
+  state
+    { facts = Failure message
+    , tokenState = Failure message
+    , pendingRequests = Failure message
+    , trustedRoot = Failure message
+    }
+
+requestPhase :: Number -> TokenState -> PendingRequest -> RequestPhase
+requestPhase nowMillis tokenState request =
+  let
+    age = nowMillis - request.submitted_at
+  in
+    if age <= tokenState.process_time then
+      PhaseProcessable
+    else if age <= tokenState.process_time + tokenState.retract_time then
+      PhaseRetractable
+    else
+      PhaseExpired
+
+phaseLabel :: RequestPhase -> String
+phaseLabel = case _ of
+  PhaseProcessable -> "processable"
+  PhaseRetractable -> "retractable"
+  PhaseExpired -> "expired"
+
+setFactLookupKey :: String -> AppState -> AppState
+setFactLookupKey key state =
+  state
+    { factLookup =
+        state.factLookup
+          { key = key
+          , value = NotAsked
+          , verification = VerificationNotAsked
+          }
+    }
+
+startFactLookup :: String -> AppState -> AppState
+startFactLookup key state =
+  state
+    { factLookup =
+        state.factLookup
+          { key = key
+          , value = Loading
+          , verification = VerificationNotAsked
+          }
+    }
+
+finishFactLookup :: String -> AppState -> AppState
+finishFactLookup value state =
+  state
+    { factLookup =
+        state.factLookup
+          { value = Success value
+          , verification = VerificationNotAsked
+          }
+    }
+
+failFactLookup :: String -> AppState -> AppState
+failFactLookup message state =
+  state
+    { factLookup =
+        state.factLookup
+          { value = Failure message
+          , verification = VerificationNotAsked
+          }
+    }
+
+setFactProofEnvelope :: String -> AppState -> AppState
+setFactProofEnvelope envelope state =
+  state
+    { factLookup =
+        state.factLookup
+          { proofEnvelope = envelope
+          , verification = VerificationNotAsked
+          }
+    }

--- a/src/MPFS/App/State.purs
+++ b/src/MPFS/App/State.purs
@@ -13,8 +13,9 @@ import Data.Maybe (Maybe(..))
 import Halogen.Query.HalogenM (SubscriptionId)
 import MPFS.App.Tab (AppTab, defaultTab)
 import MPFS.App.Verification (VerificationStatus(..))
+import MPFS.App.Write as Write
 import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
-import MPFS.Types (TokenId, TrustedRoot)
+import MPFS.Types (RequestId, TokenId, TrustedRoot)
 import MPFS.UI.Remote (Remote(..))
 import MPFS.Wallet.Cip30 (WalletApi, WalletInfo)
 
@@ -65,6 +66,9 @@ type AppState =
   , trustedRoot :: Remote TrustedRoot
   , requestNowMillis :: Number
   , factLookup :: FactLookup
+  , writeStatus :: Write.WriteStatus
+  , writeForms :: Write.WriteForms
+  , selectedRequestIds :: Array RequestId
   , walletSession :: WalletSession
   }
 
@@ -85,6 +89,9 @@ defaultState =
       , proofEnvelope: ""
       , verification: VerificationNotAsked
       }
+  , writeStatus: Write.WriteIdle
+  , writeForms: Write.initialWriteForms
+  , selectedRequestIds: []
   , walletSession:
       { status: WalletDisconnected
       , wallets: NotAsked

--- a/src/MPFS/App/State.purs
+++ b/src/MPFS/App/State.purs
@@ -1,5 +1,6 @@
 module MPFS.App.State
   ( AppState
+  , FactLookup
   , WalletSession
   , WalletStatus(..)
   , defaultState
@@ -10,7 +11,9 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import MPFS.App.Tab (AppTab, defaultTab)
-import MPFS.Types (TokenId)
+import MPFS.App.Verification (VerificationStatus(..))
+import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
+import MPFS.Types (TokenId, TrustedRoot)
 import MPFS.UI.Remote (Remote(..))
 
 data WalletStatus
@@ -33,13 +36,24 @@ type WalletSession =
   , address :: Maybe String
   }
 
+type FactLookup =
+  { key :: String
+  , value :: Remote String
+  , proofEnvelope :: String
+  , verification :: VerificationStatus
+  }
+
 type AppState =
   { activeTab :: AppTab
   , selectedToken :: Maybe TokenId
   , baseUrl :: String
   , tokens :: Remote (Array TokenId)
-  , facts :: Remote Unit
-  , trustedRoot :: Remote Unit
+  , facts :: Remote (Array FactEntry)
+  , tokenState :: Remote TokenState
+  , pendingRequests :: Remote (Array PendingRequest)
+  , trustedRoot :: Remote TrustedRoot
+  , requestNowMillis :: Number
+  , factLookup :: FactLookup
   , walletSession :: WalletSession
   }
 
@@ -50,7 +64,16 @@ defaultState =
   , baseUrl: "/api"
   , tokens: NotAsked
   , facts: NotAsked
+  , tokenState: NotAsked
+  , pendingRequests: NotAsked
   , trustedRoot: NotAsked
+  , requestNowMillis: 0.0
+  , factLookup:
+      { key: ""
+      , value: NotAsked
+      , proofEnvelope: ""
+      , verification: VerificationNotAsked
+      }
   , walletSession:
       { status: WalletDisconnected
       , walletName: Nothing

--- a/src/MPFS/App/State.purs
+++ b/src/MPFS/App/State.purs
@@ -1,0 +1,63 @@
+module MPFS.App.State
+  ( AppState
+  , WalletSession
+  , WalletStatus(..)
+  , defaultState
+  , selectTab
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import MPFS.App.Tab (AppTab, defaultTab)
+import MPFS.Types (TokenId)
+import MPFS.UI.Remote (Remote(..))
+
+data WalletStatus
+  = WalletDisconnected
+  | WalletConnecting
+  | WalletConnected
+
+derive instance Eq WalletStatus
+
+instance Show WalletStatus where
+  show = case _ of
+    WalletDisconnected -> "WalletDisconnected"
+    WalletConnecting -> "WalletConnecting"
+    WalletConnected -> "WalletConnected"
+
+type WalletSession =
+  { status :: WalletStatus
+  , walletName :: Maybe String
+  , network :: Maybe String
+  , address :: Maybe String
+  }
+
+type AppState =
+  { activeTab :: AppTab
+  , selectedToken :: Maybe TokenId
+  , baseUrl :: String
+  , tokens :: Remote (Array TokenId)
+  , facts :: Remote Unit
+  , trustedRoot :: Remote Unit
+  , walletSession :: WalletSession
+  }
+
+defaultState :: AppState
+defaultState =
+  { activeTab: defaultTab
+  , selectedToken: Nothing
+  , baseUrl: "/api"
+  , tokens: NotAsked
+  , facts: NotAsked
+  , trustedRoot: NotAsked
+  , walletSession:
+      { status: WalletDisconnected
+      , walletName: Nothing
+      , network: Nothing
+      , address: Nothing
+      }
+  }
+
+selectTab :: AppTab -> AppState -> AppState
+selectTab tab state = state { activeTab = tab }

--- a/src/MPFS/App/State.purs
+++ b/src/MPFS/App/State.purs
@@ -10,11 +10,13 @@ module MPFS.App.State
 import Prelude
 
 import Data.Maybe (Maybe(..))
+import Halogen.Query.HalogenM (SubscriptionId)
 import MPFS.App.Tab (AppTab, defaultTab)
 import MPFS.App.Verification (VerificationStatus(..))
 import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
 import MPFS.Types (TokenId, TrustedRoot)
 import MPFS.UI.Remote (Remote(..))
+import MPFS.Wallet.Cip30 (WalletApi, WalletInfo)
 
 data WalletStatus
   = WalletDisconnected
@@ -31,9 +33,18 @@ instance Show WalletStatus where
 
 type WalletSession =
   { status :: WalletStatus
+  , wallets :: Remote (Array WalletInfo)
+  , walletKey :: Maybe String
   , walletName :: Maybe String
+  , networkId :: Maybe Int
   , network :: Maybe String
-  , address :: Maybe String
+  , selectedAddress :: Maybe String
+  , changeAddress :: Maybe String
+  , usedAddresses :: Array String
+  , lovelace :: Maybe String
+  , feedback :: Maybe String
+  , api :: Maybe WalletApi
+  , subscriptionId :: Maybe SubscriptionId
   }
 
 type FactLookup =
@@ -76,9 +87,18 @@ defaultState =
       }
   , walletSession:
       { status: WalletDisconnected
+      , wallets: NotAsked
+      , walletKey: Nothing
       , walletName: Nothing
+      , networkId: Nothing
       , network: Nothing
-      , address: Nothing
+      , selectedAddress: Nothing
+      , changeAddress: Nothing
+      , usedAddresses: []
+      , lovelace: Nothing
+      , feedback: Nothing
+      , api: Nothing
+      , subscriptionId: Nothing
       }
   }
 

--- a/src/MPFS/App/Tab.purs
+++ b/src/MPFS/App/Tab.purs
@@ -1,0 +1,53 @@
+module MPFS.App.Tab
+  ( AppTab(..)
+  , allTabs
+  , defaultTab
+  , tabLabel
+  , tabSlug
+  , tabFromSlug
+  ) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Maybe (Maybe)
+
+data AppTab
+  = ConnectTab
+  | TokensTab
+  | FactsTab
+  | EndTab
+
+derive instance Eq AppTab
+derive instance Ord AppTab
+
+instance Show AppTab where
+  show = case _ of
+    ConnectTab -> "ConnectTab"
+    TokensTab -> "TokensTab"
+    FactsTab -> "FactsTab"
+    EndTab -> "EndTab"
+
+allTabs :: Array AppTab
+allTabs = [ ConnectTab, TokensTab, FactsTab, EndTab ]
+
+defaultTab :: AppTab
+defaultTab = ConnectTab
+
+tabLabel :: AppTab -> String
+tabLabel = case _ of
+  ConnectTab -> "Connect"
+  TokensTab -> "Tokens"
+  FactsTab -> "Facts"
+  EndTab -> "End"
+
+tabSlug :: AppTab -> String
+tabSlug = case _ of
+  ConnectTab -> "connect"
+  TokensTab -> "tokens"
+  FactsTab -> "facts"
+  EndTab -> "end"
+
+tabFromSlug :: String -> Maybe AppTab
+tabFromSlug slug =
+  Array.find (\tab -> tabSlug tab == slug) allTabs

--- a/src/MPFS/App/Tokens.purs
+++ b/src/MPFS/App/Tokens.purs
@@ -1,0 +1,32 @@
+module MPFS.App.Tokens
+  ( failTokenLoad
+  , finishTokenLoad
+  , selectToken
+  , startTokenLoad
+  ) where
+
+import Data.Array as Array
+import Data.Maybe (Maybe(..))
+import MPFS.App.State (AppState)
+import MPFS.Types (TokenId)
+import MPFS.UI.Remote (Remote(..))
+
+startTokenLoad :: AppState -> AppState
+startTokenLoad state = state { tokens = Loading }
+
+finishTokenLoad :: Array TokenId -> AppState -> AppState
+finishTokenLoad tokens state =
+  state
+    { tokens = Success tokens
+    , selectedToken = nextSelection
+    }
+  where
+  nextSelection = case state.selectedToken of
+    Just token | Array.elem token tokens -> Just token
+    _ -> Array.head tokens
+
+failTokenLoad :: String -> AppState -> AppState
+failTokenLoad message state = state { tokens = Failure message }
+
+selectToken :: TokenId -> AppState -> AppState
+selectToken token state = state { selectedToken = Just token }

--- a/src/MPFS/App/Verification.purs
+++ b/src/MPFS/App/Verification.purs
@@ -1,0 +1,66 @@
+module MPFS.App.Verification
+  ( VerificationStatus(..)
+  , finishVerification
+  , startVerification
+  , verifyFactEnvelope
+  ) where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Effect.Aff (Aff)
+import MPFS.Reactor as Reactor
+
+data VerificationStatus
+  = VerificationNotAsked
+  | VerificationLoading
+  | VerificationVerified
+  | VerificationFailed String
+
+derive instance Eq VerificationStatus
+
+instance Show VerificationStatus where
+  show = case _ of
+    VerificationNotAsked -> "VerificationNotAsked"
+    VerificationLoading -> "VerificationLoading"
+    VerificationVerified -> "VerificationVerified"
+    VerificationFailed message -> "(VerificationFailed " <> show message <> ")"
+
+startVerification
+  :: forall stateRest lookupRest
+   . { factLookup :: { verification :: VerificationStatus | lookupRest }
+     | stateRest
+     }
+  -> { factLookup :: { verification :: VerificationStatus | lookupRest }
+     | stateRest
+     }
+startVerification state =
+  state
+    { factLookup =
+        state.factLookup
+          { verification = VerificationLoading }
+    }
+
+finishVerification
+  :: forall stateRest lookupRest
+   . Either String Unit
+  -> { factLookup :: { verification :: VerificationStatus | lookupRest }
+     | stateRest
+     }
+  -> { factLookup :: { verification :: VerificationStatus | lookupRest }
+     | stateRest
+     }
+finishVerification result state =
+  state
+    { factLookup =
+        state.factLookup
+          { verification = status }
+    }
+  where
+  status = case result of
+    Right _ -> VerificationVerified
+    Left message -> VerificationFailed message
+
+verifyFactEnvelope :: String -> Aff (Either String Unit)
+verifyFactEnvelope =
+  Reactor.verifyEnvelope

--- a/src/MPFS/App/View.purs
+++ b/src/MPFS/App/View.purs
@@ -8,15 +8,23 @@ import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
+import MPFS.App.Facts (phaseLabel, requestPhase)
 import MPFS.App.State (AppState, WalletStatus(..))
 import MPFS.App.Tab (AppTab(..), allTabs, tabLabel, tabSlug)
-import MPFS.Types (TokenId(..))
+import MPFS.App.Verification (VerificationStatus(..))
+import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
+import MPFS.Types (TokenId(..), TrustedRoot(..))
 import MPFS.UI.Remote (Remote(..), remoteStatus)
 
 type AppActions action =
   { loadTokens :: action
+  , loadFacts :: action
+  , lookupFact :: action
   , selectTab :: AppTab -> action
   , selectToken :: TokenId -> action
+  , updateFactLookupKey :: String -> action
+  , updateFactProofEnvelope :: String -> action
+  , verifyFactEnvelope :: action
   }
 
 render
@@ -93,7 +101,7 @@ tabPanel :: forall action m. AppActions action -> AppState -> H.ComponentHTML ac
 tabPanel actions state = case state.activeTab of
   ConnectTab -> connectPanel state
   TokensTab -> tokensPanel actions state
-  FactsTab -> factsPanel state
+  FactsTab -> factsPanel actions state
   EndTab -> endPanel state
 
 connectPanel :: forall action m. AppState -> H.ComponentHTML action () m
@@ -132,16 +140,43 @@ tokensPanel actions state =
         ]
     ]
 
-factsPanel :: forall action m. AppState -> H.ComponentHTML action () m
-factsPanel state =
+factsPanel
+  :: forall action m
+   . AppActions action
+  -> AppState
+  -> H.ComponentHTML action () m
+factsPanel actions state =
   panelLayout "Facts" "Selected token facts"
     [ fieldLine "Token" (selectedTokenLabel state.selectedToken)
+    , fieldLine "Token state" (remoteStatus state.tokenState)
+    , fieldLine "Pending requests" (remoteStatus state.pendingRequests)
     , fieldLine "Facts" (remoteStatus state.facts)
     , fieldLine "Trusted root" (remoteStatus state.trustedRoot)
+    , tokenStateRemoteView state.tokenState
+    , trustedRootRemoteView state.trustedRoot
+    , pendingRequestsRemoteView
+        state.requestNowMillis
+        state.tokenState
+        state.pendingRequests
+    , factsRemoteView state.facts
+    , factLookupView actions state
     , HH.div
         [ HP.class_ (HH.ClassName "control-row") ]
-        [ inertButton "Load facts"
-        , inertButton "Verify proof"
+        [ HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled
+                ( state.selectedToken == Nothing
+                    || remoteIsLoading state.facts
+                    || remoteIsLoading state.tokenState
+                    || remoteIsLoading state.pendingRequests
+                )
+            , HE.onClick \_ -> actions.loadFacts
+            ]
+            [ HH.text (factsLoadLabel state.facts) ]
+        , inertButton "Add fact"
+        , inertButton "Update fact"
+        , inertButton "Delete fact"
         ]
     ]
 
@@ -228,6 +263,216 @@ tokenRemoteView actions selectedToken = case _ of
           [ HP.class_ (HH.ClassName "token-list") ]
           (map (tokenRow actions selectedToken) tokens)
 
+tokenStateRemoteView
+  :: forall action m
+   . Remote TokenState
+  -> H.ComponentHTML action () m
+tokenStateRemoteView = case _ of
+  NotAsked ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text "Token state has not been loaded." ]
+  Loading ->
+    HH.p
+      [ HP.class_ (HH.ClassName "loading-state") ]
+      [ HH.text "Loading token state..." ]
+  Failure message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "error-state") ]
+      [ HH.text ("Error loading token state: " <> message) ]
+  Success tokenState ->
+    HH.div
+      [ HP.class_ (HH.ClassName "field-group") ]
+      [ fieldLine "Owner" (shortText tokenState.owner)
+      , fieldLine "Root" (shortText tokenState.root)
+      , fieldLine "Max fee" (show tokenState.max_fee)
+      , fieldLine "Process window" (show tokenState.process_time)
+      , fieldLine "Retract window" (show tokenState.retract_time)
+      ]
+
+trustedRootRemoteView
+  :: forall action m
+   . Remote TrustedRoot
+  -> H.ComponentHTML action () m
+trustedRootRemoteView = case _ of
+  NotAsked ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text "Trusted root has not been loaded." ]
+  Loading ->
+    HH.p
+      [ HP.class_ (HH.ClassName "loading-state") ]
+      [ HH.text "Loading trusted root..." ]
+  Failure message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "error-state") ]
+      [ HH.text ("Error loading trusted root: " <> message) ]
+  Success (TrustedRoot trustedRoot) ->
+    fieldLine "Trusted root hash" (shortText trustedRoot)
+
+pendingRequestsRemoteView
+  :: forall action m
+   . Number
+  -> Remote TokenState
+  -> Remote (Array PendingRequest)
+  -> H.ComponentHTML action () m
+pendingRequestsRemoteView nowMillis tokenStateRemote = case _ of
+  NotAsked ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text "Pending requests have not been loaded." ]
+  Loading ->
+    HH.p
+      [ HP.class_ (HH.ClassName "loading-state") ]
+      [ HH.text "Loading pending requests..." ]
+  Failure message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "error-state") ]
+      [ HH.text ("Error loading pending requests: " <> message) ]
+  Success requests
+    | Array.null requests ->
+        HH.p
+          [ HP.class_ (HH.ClassName "empty-state") ]
+          [ HH.text "No pending requests." ]
+    | otherwise ->
+        case tokenStateRemote of
+          Success tokenState ->
+            HH.ul
+              [ HP.class_ (HH.ClassName "token-list") ]
+              (map (requestRow nowMillis tokenState) requests)
+          _ ->
+            HH.p
+              [ HP.class_ (HH.ClassName "empty-state") ]
+              [ HH.text "Token state is required for request phases." ]
+
+factsRemoteView
+  :: forall action m
+   . Remote (Array FactEntry)
+  -> H.ComponentHTML action () m
+factsRemoteView = case _ of
+  NotAsked ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text "Facts have not been loaded." ]
+  Loading ->
+    HH.p
+      [ HP.class_ (HH.ClassName "loading-state") ]
+      [ HH.text "Loading facts..." ]
+  Failure message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "error-state") ]
+      [ HH.text ("Error loading facts: " <> message) ]
+  Success facts
+    | Array.null facts ->
+        HH.p
+          [ HP.class_ (HH.ClassName "empty-state") ]
+          [ HH.text "No facts found." ]
+    | otherwise ->
+        HH.ul
+          [ HP.class_ (HH.ClassName "token-list") ]
+          (map factRow facts)
+
+factLookupView
+  :: forall action m
+   . AppActions action
+  -> AppState
+  -> H.ComponentHTML action () m
+factLookupView actions state =
+  HH.div
+    [ HP.class_ (HH.ClassName "field-group") ]
+    [ HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.factLookup.key
+            , HP.placeholder "Fact key"
+            , HE.onValueInput actions.updateFactLookupKey
+            ]
+        , HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled
+                ( state.selectedToken == Nothing
+                    || state.factLookup.key == ""
+                    || remoteIsLoading state.factLookup.value
+                )
+            , HE.onClick \_ -> actions.lookupFact
+            ]
+            [ HH.text "Look up" ]
+        ]
+    , factLookupRemoteView state.factLookup.value
+    , HH.textarea
+        [ HP.value state.factLookup.proofEnvelope
+        , HP.rows 4
+        , HP.placeholder "Proof envelope"
+        , HE.onValueInput actions.updateFactProofEnvelope
+        ]
+    , HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled
+                ( state.factLookup.proofEnvelope == ""
+                    || state.factLookup.verification == VerificationLoading
+                )
+            , HE.onClick \_ -> actions.verifyFactEnvelope
+            ]
+            [ HH.text "Verify proof" ]
+        , fieldLine
+            "Verification"
+            (verificationStatusLabel state.factLookup.verification)
+        ]
+    ]
+
+factLookupRemoteView
+  :: forall action m
+   . Remote String
+  -> H.ComponentHTML action () m
+factLookupRemoteView = case _ of
+  NotAsked ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text "No fact lookup has run." ]
+  Loading ->
+    HH.p
+      [ HP.class_ (HH.ClassName "loading-state") ]
+      [ HH.text "Looking up fact..." ]
+  Failure message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "error-state") ]
+      [ HH.text ("Error looking up fact: " <> message) ]
+  Success value ->
+    fieldLine "Lookup value" value
+
+requestRow
+  :: forall action m
+   . Number
+  -> TokenState
+  -> PendingRequest
+  -> H.ComponentHTML action () m
+requestRow nowMillis tokenState request =
+  HH.li
+    [ HP.attr (HH.AttrName "data-request-key") request.key ]
+    [ HH.strong_ [ HH.text request.operation ]
+    , HH.span_ [ HH.text (" key " <> request.key) ]
+    , HH.span_ [ HH.text (" value " <> requestValueText request) ]
+    , HH.span_
+        [ HH.text
+            ( " phase "
+                <> phaseLabel (requestPhase nowMillis tokenState request)
+            )
+        ]
+    ]
+
+factRow :: forall action m. FactEntry -> H.ComponentHTML action () m
+factRow fact =
+  HH.li
+    [ HP.attr (HH.AttrName "data-fact-key") fact.key ]
+    [ HH.strong_ [ HH.text fact.key ]
+    , HH.span_ [ HH.text (" " <> fact.value) ]
+    ]
+
 tokenRow
   :: forall action m
    . AppActions action
@@ -263,6 +508,33 @@ tokenLoadLabel = case _ of
   Loading -> "Loading tokens"
   Failure _ -> "Refresh tokens"
   Success _ -> "Refresh tokens"
+
+factsLoadLabel :: forall a. Remote a -> String
+factsLoadLabel = case _ of
+  NotAsked -> "Load facts"
+  Loading -> "Loading facts"
+  Failure _ -> "Refresh facts"
+  Success _ -> "Refresh facts"
+
+remoteIsLoading :: forall a. Remote a -> Boolean
+remoteIsLoading = case _ of
+  Loading -> true
+  _ -> false
+
+verificationStatusLabel :: VerificationStatus -> String
+verificationStatusLabel = case _ of
+  VerificationNotAsked -> "Not verified"
+  VerificationLoading -> "Verifying"
+  VerificationVerified -> "Verified"
+  VerificationFailed message -> "Error: " <> message
+
+requestValueText :: PendingRequest -> String
+requestValueText request = case request.value of
+  Nothing -> "none"
+  Just value -> value
+
+shortText :: String -> String
+shortText = identity
 
 walletStatusLabel :: WalletStatus -> String
 walletStatusLabel = case _ of

--- a/src/MPFS/App/View.purs
+++ b/src/MPFS/App/View.purs
@@ -12,8 +12,10 @@ import MPFS.App.Facts (phaseLabel, requestPhase)
 import MPFS.App.State (AppState, WalletStatus(..))
 import MPFS.App.Tab (AppTab(..), allTabs, tabLabel, tabSlug)
 import MPFS.App.Verification (VerificationStatus(..))
+import MPFS.App.Write as Write
+import MPFS.App.Write (WriteStatus(..))
 import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
-import MPFS.Types (TokenId(..), TrustedRoot(..))
+import MPFS.Types (RequestId, TokenId(..), TrustedRoot(..))
 import MPFS.UI.Remote (Remote(..), remoteStatus)
 import MPFS.Wallet.Cip30 (WalletInfo)
 
@@ -24,6 +26,22 @@ type AppActions action =
   , disconnectWallet :: action
   , loadTokens :: action
   , loadFacts :: action
+  , registerToken :: action
+  , updateInsertKey :: String -> action
+  , updateInsertValue :: String -> action
+  , submitInsertFact :: action
+  , updateUpdateKey :: String -> action
+  , updateUpdateOldValue :: String -> action
+  , updateUpdateNewValue :: String -> action
+  , submitUpdateFact :: action
+  , updateDeleteKey :: String -> action
+  , updateDeleteValue :: String -> action
+  , submitDeleteFact :: action
+  , toggleRequestSelection :: RequestId -> action
+  , retractRequest :: RequestId -> action
+  , rejectExpired :: action
+  , updateToken :: action
+  , endCage :: action
   , lookupFact :: action
   , selectTab :: AppTab -> action
   , selectToken :: TokenId -> action
@@ -107,7 +125,7 @@ tabPanel actions state = case state.activeTab of
   ConnectTab -> connectPanel actions state
   TokensTab -> tokensPanel actions state
   FactsTab -> factsPanel actions state
-  EndTab -> endPanel state
+  EndTab -> endPanel actions state
 
 connectPanel
   :: forall action m
@@ -134,6 +152,7 @@ tokensPanel actions state =
     [ fieldLine "Token list" (remoteStatus state.tokens)
     , fieldLine "Selected token" (selectedTokenLabel state.selectedToken)
     , tokenRemoteView actions state.selectedToken state.tokens
+    , writeStatusView state.writeStatus
     , HH.div
         [ HP.class_ (HH.ClassName "control-row") ]
         [ HH.button
@@ -143,7 +162,13 @@ tokensPanel actions state =
             , HE.onClick \_ -> actions.loadTokens
             ]
             [ HH.text (tokenLoadLabel state.tokens) ]
-        , inertButton "Register token"
+        , HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled (not (canWriteWithoutToken state))
+            , HE.onClick \_ -> actions.registerToken
+            ]
+            [ HH.text "Register token" ]
         ]
     ]
 
@@ -162,11 +187,15 @@ factsPanel actions state =
     , tokenStateRemoteView state.tokenState
     , trustedRootRemoteView state.trustedRoot
     , pendingRequestsRemoteView
+        actions
         state.requestNowMillis
         state.tokenState
+        state.selectedRequestIds
         state.pendingRequests
     , factsRemoteView state.facts
     , factLookupView actions state
+    , factWriteForms actions state
+    , writeStatusView state.writeStatus
     , HH.div
         [ HP.class_ (HH.ClassName "control-row") ]
         [ HH.button
@@ -181,22 +210,40 @@ factsPanel actions state =
             , HE.onClick \_ -> actions.loadFacts
             ]
             [ HH.text (factsLoadLabel state.facts) ]
-        , inertButton "Add fact"
-        , inertButton "Update fact"
-        , inertButton "Delete fact"
+        , HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled (not (canWriteSelected state))
+            , HE.onClick \_ -> actions.updateToken
+            ]
+            [ HH.text "Process selected" ]
+        , HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "inert-button")
+            , HP.disabled (not (canWriteSelected state))
+            , HE.onClick \_ -> actions.rejectExpired
+            ]
+            [ HH.text "Reject expired" ]
         ]
     ]
 
-endPanel :: forall action m. AppState -> H.ComponentHTML action () m
-endPanel state =
+endPanel :: forall action m. AppActions action -> AppState -> H.ComponentHTML action () m
+endPanel actions state =
   panelLayout "End" "Cage lifecycle"
     [ fieldLine "Token" (selectedTokenLabel state.selectedToken)
     , fieldLine "Wallet" (walletSessionLabel state)
     , fieldLine "Wallet network" (maybeText state.walletSession.network)
     , fieldLine "Wallet address" (maybeText state.walletSession.selectedAddress)
+    , writeStatusView state.writeStatus
     , HH.div
         [ HP.class_ (HH.ClassName "control-row") ]
-        [ inertButton "End cage"
+        [ HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled (not (canWriteSelected state))
+            , HE.onClick \_ -> actions.endCage
+            ]
+            [ HH.text "End cage" ]
         ]
     ]
 
@@ -233,15 +280,6 @@ statusPill label value =
     [ HH.span_ [ HH.text label ]
     , HH.strong_ [ HH.text value ]
     ]
-
-inertButton :: forall action m. String -> H.ComponentHTML action () m
-inertButton label =
-  HH.button
-    [ HP.type_ HP.ButtonButton
-    , HP.disabled true
-    , HP.class_ (HH.ClassName "inert-button")
-    ]
-    [ HH.text label ]
 
 tokenRemoteView
   :: forall action m
@@ -424,11 +462,13 @@ trustedRootRemoteView = case _ of
 
 pendingRequestsRemoteView
   :: forall action m
-   . Number
+   . AppActions action
+  -> Number
   -> Remote TokenState
+  -> Array RequestId
   -> Remote (Array PendingRequest)
   -> H.ComponentHTML action () m
-pendingRequestsRemoteView nowMillis tokenStateRemote = case _ of
+pendingRequestsRemoteView actions nowMillis tokenStateRemote selectedRequestIds = case _ of
   NotAsked ->
     HH.p
       [ HP.class_ (HH.ClassName "empty-state") ]
@@ -451,7 +491,7 @@ pendingRequestsRemoteView nowMillis tokenStateRemote = case _ of
           Success tokenState ->
             HH.ul
               [ HP.class_ (HH.ClassName "token-list") ]
-              (map (requestRow nowMillis tokenState) requests)
+              (map (requestRow actions nowMillis tokenState selectedRequestIds) requests)
           _ ->
             HH.p
               [ HP.class_ (HH.ClassName "empty-state") ]
@@ -537,6 +577,101 @@ factLookupView actions state =
         ]
     ]
 
+factWriteForms
+  :: forall action m
+   . AppActions action
+  -> AppState
+  -> H.ComponentHTML action () m
+factWriteForms actions state =
+  HH.div
+    [ HP.class_ (HH.ClassName "field-group") ]
+    [ HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.writeForms.insertKey
+            , HP.placeholder "Insert key"
+            , HE.onValueInput actions.updateInsertKey
+            ]
+        , HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.writeForms.insertValue
+            , HP.placeholder "Insert value"
+            , HE.onValueInput actions.updateInsertValue
+            ]
+        , HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled
+                ( not (canWriteSelected state)
+                    || state.writeForms.insertKey == ""
+                    || state.writeForms.insertValue == ""
+                )
+            , HE.onClick \_ -> actions.submitInsertFact
+            ]
+            [ HH.text "Insert fact" ]
+        ]
+    , HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.writeForms.updateKey
+            , HP.placeholder "Update key"
+            , HE.onValueInput actions.updateUpdateKey
+            ]
+        , HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.writeForms.updateOldValue
+            , HP.placeholder "Old value"
+            , HE.onValueInput actions.updateUpdateOldValue
+            ]
+        , HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.writeForms.updateNewValue
+            , HP.placeholder "New value"
+            , HE.onValueInput actions.updateUpdateNewValue
+            ]
+        , HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled
+                ( not (canWriteSelected state)
+                    || state.writeForms.updateKey == ""
+                    || state.writeForms.updateOldValue == ""
+                    || state.writeForms.updateNewValue == ""
+                )
+            , HE.onClick \_ -> actions.submitUpdateFact
+            ]
+            [ HH.text "Update fact" ]
+        ]
+    , HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.writeForms.deleteKey
+            , HP.placeholder "Delete key"
+            , HE.onValueInput actions.updateDeleteKey
+            ]
+        , HH.input
+            [ HP.type_ HP.InputText
+            , HP.value state.writeForms.deleteValue
+            , HP.placeholder "Delete value"
+            , HE.onValueInput actions.updateDeleteValue
+            ]
+        , HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled
+                ( not (canWriteSelected state)
+                    || state.writeForms.deleteKey == ""
+                    || state.writeForms.deleteValue == ""
+                )
+            , HE.onClick \_ -> actions.submitDeleteFact
+            ]
+            [ HH.text "Delete fact" ]
+        ]
+    ]
+
 factLookupRemoteView
   :: forall action m
    . Remote String
@@ -559,23 +694,50 @@ factLookupRemoteView = case _ of
 
 requestRow
   :: forall action m
-   . Number
+   . AppActions action
+  -> Number
   -> TokenState
+  -> Array RequestId
   -> PendingRequest
   -> H.ComponentHTML action () m
-requestRow nowMillis tokenState request =
+requestRow actions nowMillis tokenState selectedRequestIds request =
   HH.li
     [ HP.attr (HH.AttrName "data-request-key") request.key ]
-    [ HH.strong_ [ HH.text request.operation ]
-    , HH.span_ [ HH.text (" key " <> request.key) ]
-    , HH.span_ [ HH.text (" value " <> requestValueText request) ]
-    , HH.span_
-        [ HH.text
-            ( " phase "
-                <> phaseLabel (requestPhase nowMillis tokenState request)
-            )
-        ]
-    ]
+    ( [ HH.strong_ [ HH.text request.operation ]
+      , HH.span_ [ HH.text (" key " <> request.key) ]
+      , HH.span_ [ HH.text (" value " <> requestValueText request) ]
+      , HH.span_
+          [ HH.text
+              ( " phase "
+                  <> phaseLabel (requestPhase nowMillis tokenState request)
+              )
+          ]
+      ]
+        <> requestControls
+    )
+  where
+  requestControls = case Write.requestIdOf request of
+    Nothing ->
+      [ HH.span_ [ HH.text " missing request id" ] ]
+    Just requestId ->
+      [ HH.button
+          [ HP.type_ HP.ButtonButton
+          , HP.class_ (HH.ClassName "inert-button")
+          , HE.onClick \_ -> actions.toggleRequestSelection requestId
+          ]
+          [ HH.text
+              if Array.elem requestId selectedRequestIds then
+                "Selected"
+              else
+                "Select"
+          ]
+      , HH.button
+          [ HP.type_ HP.ButtonButton
+          , HP.class_ (HH.ClassName "inert-button")
+          , HE.onClick \_ -> actions.retractRequest requestId
+          ]
+          [ HH.text "Retract" ]
+      ]
 
 factRow :: forall action m. FactEntry -> H.ComponentHTML action () m
 factRow fact =
@@ -639,6 +801,44 @@ remoteIsLoading :: forall a. Remote a -> Boolean
 remoteIsLoading = case _ of
   Loading -> true
   _ -> false
+
+writeStatusView :: forall action m. WriteStatus -> H.ComponentHTML action () m
+writeStatusView = case _ of
+  WriteIdle ->
+    HH.text ""
+  WriteBuilding ->
+    HH.p [ HP.class_ (HH.ClassName "loading-state") ] [ HH.text "Building transaction..." ]
+  WriteBuilt _ ->
+    HH.p [ HP.class_ (HH.ClassName "loading-state") ] [ HH.text "Unsigned transaction built." ]
+  WriteSigning _ ->
+    HH.p [ HP.class_ (HH.ClassName "loading-state") ] [ HH.text "Waiting for wallet signature..." ]
+  WriteAssembling _ _ ->
+    HH.p [ HP.class_ (HH.ClassName "loading-state") ] [ HH.text "Assembling signed transaction..." ]
+  WriteSubmitting _ _ _ ->
+    HH.p [ HP.class_ (HH.ClassName "loading-state") ] [ HH.text "Submitting transaction..." ]
+  WriteSubmitted _ _ _ txId ->
+    HH.p [ HP.class_ (HH.ClassName "empty-state") ] [ HH.text ("Submitted transaction " <> txId) ]
+  WriteFailed message ->
+    HH.p [ HP.class_ (HH.ClassName "error-state") ] [ HH.text message ]
+
+writeBusy :: WriteStatus -> Boolean
+writeBusy = case _ of
+  WriteBuilding -> true
+  WriteBuilt _ -> true
+  WriteSigning _ -> true
+  WriteAssembling _ _ -> true
+  WriteSubmitting _ _ _ -> true
+  _ -> false
+
+canWriteWithoutToken :: AppState -> Boolean
+canWriteWithoutToken state =
+  state.walletSession.status == WalletConnected
+    && state.walletSession.selectedAddress /= Nothing
+    && not (writeBusy state.writeStatus)
+
+canWriteSelected :: AppState -> Boolean
+canWriteSelected state =
+  canWriteWithoutToken state && state.selectedToken /= Nothing
 
 verificationStatusLabel :: VerificationStatus -> String
 verificationStatusLabel = case _ of

--- a/src/MPFS/App/View.purs
+++ b/src/MPFS/App/View.purs
@@ -2,6 +2,7 @@ module MPFS.App.View (render) where
 
 import Prelude
 
+import Data.Array as Array
 import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
@@ -10,14 +11,20 @@ import Halogen.HTML.Properties as HP
 import MPFS.App.State (AppState, WalletStatus(..))
 import MPFS.App.Tab (AppTab(..), allTabs, tabLabel, tabSlug)
 import MPFS.Types (TokenId(..))
-import MPFS.UI.Remote (remoteStatus)
+import MPFS.UI.Remote (Remote(..), remoteStatus)
+
+type AppActions action =
+  { loadTokens :: action
+  , selectTab :: AppTab -> action
+  , selectToken :: TokenId -> action
+  }
 
 render
   :: forall action m
-   . (AppTab -> action)
+   . AppActions action
   -> AppState
   -> H.ComponentHTML action () m
-render toAction state =
+render actions state =
   HH.main
     [ HP.class_ (HH.ClassName "app-shell") ]
     [ header state
@@ -25,12 +32,12 @@ render toAction state =
         [ HP.class_ (HH.ClassName "tab-strip")
         , HP.attr (HH.AttrName "aria-label") "MPFS workbench tabs"
         ]
-        (map (tabButton toAction state.activeTab) allTabs)
+        (map (tabButton actions.selectTab state.activeTab) allTabs)
     , HH.section
         [ HP.class_ (HH.ClassName "panel")
         , HP.attr (HH.AttrName "aria-live") "polite"
         ]
-        [ tabPanel state ]
+        [ tabPanel actions state ]
     ]
 
 header :: forall action m. AppState -> H.ComponentHTML action () m
@@ -82,10 +89,10 @@ tabButton toAction activeTab tab =
     else
       [ "tab-button" ]
 
-tabPanel :: forall action m. AppState -> H.ComponentHTML action () m
-tabPanel state = case state.activeTab of
+tabPanel :: forall action m. AppActions action -> AppState -> H.ComponentHTML action () m
+tabPanel actions state = case state.activeTab of
   ConnectTab -> connectPanel state
-  TokensTab -> tokensPanel state
+  TokensTab -> tokensPanel actions state
   FactsTab -> factsPanel state
   EndTab -> endPanel state
 
@@ -102,14 +109,25 @@ connectPanel state =
         ]
     ]
 
-tokensPanel :: forall action m. AppState -> H.ComponentHTML action () m
-tokensPanel state =
+tokensPanel
+  :: forall action m
+   . AppActions action
+  -> AppState
+  -> H.ComponentHTML action () m
+tokensPanel actions state =
   panelLayout "Tokens" "Token registry"
     [ fieldLine "Token list" (remoteStatus state.tokens)
     , fieldLine "Selected token" (selectedTokenLabel state.selectedToken)
+    , tokenRemoteView actions state.selectedToken state.tokens
     , HH.div
         [ HP.class_ (HH.ClassName "control-row") ]
-        [ inertButton "Load tokens"
+        [ HH.button
+            [ HP.type_ HP.ButtonButton
+            , HP.class_ (HH.ClassName "primary-button")
+            , HP.disabled (state.tokens == Loading)
+            , HE.onClick \_ -> actions.loadTokens
+            ]
+            [ HH.text (tokenLoadLabel state.tokens) ]
         , inertButton "Register token"
         ]
     ]
@@ -180,6 +198,71 @@ inertButton label =
     , HP.class_ (HH.ClassName "inert-button")
     ]
     [ HH.text label ]
+
+tokenRemoteView
+  :: forall action m
+   . AppActions action
+  -> Maybe TokenId
+  -> Remote (Array TokenId)
+  -> H.ComponentHTML action () m
+tokenRemoteView actions selectedToken = case _ of
+  NotAsked ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text "Tokens have not been loaded." ]
+  Loading ->
+    HH.p
+      [ HP.class_ (HH.ClassName "loading-state") ]
+      [ HH.text "Loading tokens..." ]
+  Failure message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "error-state") ]
+      [ HH.text ("Error loading tokens: " <> message) ]
+  Success tokens
+    | Array.null tokens ->
+        HH.p
+          [ HP.class_ (HH.ClassName "empty-state") ]
+          [ HH.text "No tokens registered." ]
+    | otherwise ->
+        HH.ul
+          [ HP.class_ (HH.ClassName "token-list") ]
+          (map (tokenRow actions selectedToken) tokens)
+
+tokenRow
+  :: forall action m
+   . AppActions action
+  -> Maybe TokenId
+  -> TokenId
+  -> H.ComponentHTML action () m
+tokenRow actions selectedToken token@(TokenId tokenId) =
+  HH.li
+    [ HP.attr (HH.AttrName "data-token") tokenId ]
+    [ HH.button
+        [ HP.type_ HP.ButtonButton
+        , HP.classes (map HH.ClassName classes)
+        , HP.attr (HH.AttrName "aria-pressed") pressed
+        , HE.onClick \_ -> actions.selectToken token
+        ]
+        [ HH.text tokenId ]
+    ]
+  where
+  isSelected = selectedToken == Just token
+
+  pressed =
+    if isSelected then "true" else "false"
+
+  classes =
+    if isSelected then
+      [ "token-row", "is-selected" ]
+    else
+      [ "token-row" ]
+
+tokenLoadLabel :: forall a. Remote a -> String
+tokenLoadLabel = case _ of
+  NotAsked -> "Load tokens"
+  Loading -> "Loading tokens"
+  Failure _ -> "Refresh tokens"
+  Success _ -> "Refresh tokens"
 
 walletStatusLabel :: WalletStatus -> String
 walletStatusLabel = case _ of

--- a/src/MPFS/App/View.purs
+++ b/src/MPFS/App/View.purs
@@ -15,9 +15,14 @@ import MPFS.App.Verification (VerificationStatus(..))
 import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
 import MPFS.Types (TokenId(..), TrustedRoot(..))
 import MPFS.UI.Remote (Remote(..), remoteStatus)
+import MPFS.Wallet.Cip30 (WalletInfo)
 
 type AppActions action =
-  { loadTokens :: action
+  { loadWallets :: action
+  , connectWallet :: WalletInfo -> action
+  , refreshWallet :: action
+  , disconnectWallet :: action
+  , loadTokens :: action
   , loadFacts :: action
   , lookupFact :: action
   , selectTab :: AppTab -> action
@@ -61,7 +66,7 @@ header state =
     , HH.div
         [ HP.class_ (HH.ClassName "status-row") ]
         [ statusPill "Client" state.baseUrl
-        , statusPill "Wallet" (walletStatusLabel state.walletSession.status)
+        , statusPill "Wallet" (walletSessionLabel state)
         , statusPill "Token" (selectedTokenLabel state.selectedToken)
         ]
     ]
@@ -99,22 +104,24 @@ tabButton toAction activeTab tab =
 
 tabPanel :: forall action m. AppActions action -> AppState -> H.ComponentHTML action () m
 tabPanel actions state = case state.activeTab of
-  ConnectTab -> connectPanel state
+  ConnectTab -> connectPanel actions state
   TokensTab -> tokensPanel actions state
   FactsTab -> factsPanel actions state
   EndTab -> endPanel state
 
-connectPanel :: forall action m. AppState -> H.ComponentHTML action () m
-connectPanel state =
+connectPanel
+  :: forall action m
+   . AppActions action
+  -> AppState
+  -> H.ComponentHTML action () m
+connectPanel actions state =
   panelLayout "Connect" "Wallet session"
-    [ fieldLine "Session" (walletStatusLabel state.walletSession.status)
+    [ fieldLine "Session" (walletSessionLabel state)
     , fieldLine "Network" (maybeText state.walletSession.network)
-    , fieldLine "Address" (maybeText state.walletSession.address)
-    , HH.div
-        [ HP.class_ (HH.ClassName "control-row") ]
-        [ inertButton "Connect wallet"
-        , inertButton "Refresh"
-        ]
+    , fieldLine "Address" (maybeText state.walletSession.selectedAddress)
+    , fieldLine "Balance" (lovelaceText state.walletSession.lovelace)
+    , walletFeedback state.walletSession.feedback
+    , walletControls actions state
     ]
 
 tokensPanel
@@ -184,7 +191,9 @@ endPanel :: forall action m. AppState -> H.ComponentHTML action () m
 endPanel state =
   panelLayout "End" "Cage lifecycle"
     [ fieldLine "Token" (selectedTokenLabel state.selectedToken)
-    , fieldLine "Wallet" (walletStatusLabel state.walletSession.status)
+    , fieldLine "Wallet" (walletSessionLabel state)
+    , fieldLine "Wallet network" (maybeText state.walletSession.network)
+    , fieldLine "Wallet address" (maybeText state.walletSession.selectedAddress)
     , HH.div
         [ HP.class_ (HH.ClassName "control-row") ]
         [ inertButton "End cage"
@@ -262,6 +271,109 @@ tokenRemoteView actions selectedToken = case _ of
         HH.ul
           [ HP.class_ (HH.ClassName "token-list") ]
           (map (tokenRow actions selectedToken) tokens)
+
+walletControls
+  :: forall action m
+   . AppActions action
+  -> AppState
+  -> H.ComponentHTML action () m
+walletControls actions state = case state.walletSession.status of
+  WalletConnected ->
+    HH.div
+      [ HP.class_ (HH.ClassName "control-row") ]
+      [ HH.button
+          [ HP.type_ HP.ButtonButton
+          , HP.class_ (HH.ClassName "primary-button")
+          , HE.onClick \_ -> actions.refreshWallet
+          ]
+          [ HH.text "Refresh wallet" ]
+      , HH.button
+          [ HP.type_ HP.ButtonButton
+          , HP.class_ (HH.ClassName "inert-button")
+          , HE.onClick \_ -> actions.disconnectWallet
+          ]
+          [ HH.text "Disconnect" ]
+      ]
+  _ ->
+    HH.div_
+      [ walletRemoteView actions state.walletSession.status
+          state.walletSession.wallets
+      , HH.div
+          [ HP.class_ (HH.ClassName "control-row") ]
+          [ HH.button
+              [ HP.type_ HP.ButtonButton
+              , HP.class_ (HH.ClassName "primary-button")
+              , HP.disabled (state.walletSession.wallets == Loading)
+              , HE.onClick \_ -> actions.loadWallets
+              ]
+              [ HH.text (walletDiscoveryLabel state.walletSession.wallets) ]
+          ]
+      ]
+
+walletRemoteView
+  :: forall action m
+   . AppActions action
+  -> WalletStatus
+  -> Remote (Array WalletInfo)
+  -> H.ComponentHTML action () m
+walletRemoteView actions status = case _ of
+  NotAsked ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text "Wallet discovery has not run." ]
+  Loading ->
+    HH.p
+      [ HP.class_ (HH.ClassName "loading-state") ]
+      [ HH.text "Looking for CIP-30 wallets..." ]
+  Failure message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "error-state") ]
+      [ HH.text ("Error discovering wallets: " <> message) ]
+  Success wallets
+    | Array.null wallets ->
+        HH.p
+          [ HP.class_ (HH.ClassName "empty-state") ]
+          [ HH.text "No CIP-30 wallet found." ]
+    | otherwise ->
+        HH.ul
+          [ HP.class_ (HH.ClassName "token-list") ]
+          (map (walletRow actions status) wallets)
+
+walletRow
+  :: forall action m
+   . AppActions action
+  -> WalletStatus
+  -> WalletInfo
+  -> H.ComponentHTML action () m
+walletRow actions status wallet =
+  HH.li
+    [ HP.attr (HH.AttrName "data-wallet") wallet.key ]
+    [ HH.strong_ [ HH.text wallet.name ]
+    , HH.button
+        [ HP.type_ HP.ButtonButton
+        , HP.class_ (HH.ClassName "primary-button")
+        , HP.disabled (status == WalletConnecting)
+        , HE.onClick \_ -> actions.connectWallet wallet
+        ]
+        [ HH.text
+            if status == WalletConnecting then
+              "Connecting"
+            else
+              "Connect"
+        ]
+    ]
+
+walletFeedback
+  :: forall action m
+   . Maybe String
+  -> H.ComponentHTML action () m
+walletFeedback = case _ of
+  Nothing ->
+    HH.text ""
+  Just message ->
+    HH.p
+      [ HP.class_ (HH.ClassName "empty-state") ]
+      [ HH.text message ]
 
 tokenStateRemoteView
   :: forall action m
@@ -516,6 +628,13 @@ factsLoadLabel = case _ of
   Failure _ -> "Refresh facts"
   Success _ -> "Refresh facts"
 
+walletDiscoveryLabel :: forall a. Remote a -> String
+walletDiscoveryLabel = case _ of
+  NotAsked -> "Find wallets"
+  Loading -> "Finding wallets"
+  Failure _ -> "Refresh wallets"
+  Success _ -> "Refresh wallets"
+
 remoteIsLoading :: forall a. Remote a -> Boolean
 remoteIsLoading = case _ of
   Loading -> true
@@ -541,6 +660,17 @@ walletStatusLabel = case _ of
   WalletDisconnected -> "Not connected"
   WalletConnecting -> "Connecting"
   WalletConnected -> "Connected"
+
+walletSessionLabel :: AppState -> String
+walletSessionLabel state = case state.walletSession.status, state.walletSession.walletName of
+  WalletConnected, Just name -> "Connected: " <> name
+  WalletConnecting, Just name -> "Connecting: " <> name
+  _, _ -> walletStatusLabel state.walletSession.status
+
+lovelaceText :: Maybe String -> String
+lovelaceText = case _ of
+  Nothing -> "Unavailable"
+  Just value -> value <> " lovelace"
 
 selectedTokenLabel :: Maybe TokenId -> String
 selectedTokenLabel = case _ of

--- a/src/MPFS/App/View.purs
+++ b/src/MPFS/App/View.purs
@@ -1,0 +1,198 @@
+module MPFS.App.View (render) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import MPFS.App.State (AppState, WalletStatus(..))
+import MPFS.App.Tab (AppTab(..), allTabs, tabLabel, tabSlug)
+import MPFS.Types (TokenId(..))
+import MPFS.UI.Remote (remoteStatus)
+
+render
+  :: forall action m
+   . (AppTab -> action)
+  -> AppState
+  -> H.ComponentHTML action () m
+render toAction state =
+  HH.main
+    [ HP.class_ (HH.ClassName "app-shell") ]
+    [ header state
+    , HH.nav
+        [ HP.class_ (HH.ClassName "tab-strip")
+        , HP.attr (HH.AttrName "aria-label") "MPFS workbench tabs"
+        ]
+        (map (tabButton toAction state.activeTab) allTabs)
+    , HH.section
+        [ HP.class_ (HH.ClassName "panel")
+        , HP.attr (HH.AttrName "aria-live") "polite"
+        ]
+        [ tabPanel state ]
+    ]
+
+header :: forall action m. AppState -> H.ComponentHTML action () m
+header state =
+  HH.header
+    [ HP.class_ (HH.ClassName "shell-header") ]
+    [ HH.div_
+        [ HH.p
+            [ HP.class_ (HH.ClassName "eyebrow") ]
+            [ HH.text "MPFS Browser" ]
+        , HH.h1_ [ HH.text "Fact workbench" ]
+        ]
+    , HH.div
+        [ HP.class_ (HH.ClassName "status-row") ]
+        [ statusPill "Client" state.baseUrl
+        , statusPill "Wallet" (walletStatusLabel state.walletSession.status)
+        , statusPill "Token" (selectedTokenLabel state.selectedToken)
+        ]
+    ]
+
+tabButton
+  :: forall action m
+   . (AppTab -> action)
+  -> AppTab
+  -> AppTab
+  -> H.ComponentHTML action () m
+tabButton toAction activeTab tab =
+  HH.button
+    [ HP.type_ HP.ButtonButton
+    , HP.classes (map HH.ClassName classes)
+    , HP.attr (HH.AttrName "aria-selected") selected
+    , HP.attr (HH.AttrName "data-tab") (tabSlug tab)
+    , HE.onClick \_ -> toAction tab
+    ]
+    [ HH.span
+        [ HP.class_ (HH.ClassName "tab-marker") ]
+        []
+    , HH.text (tabLabel tab)
+    ]
+  where
+  isActive = activeTab == tab
+
+  selected =
+    if isActive then "true" else "false"
+
+  classes =
+    if isActive then
+      [ "tab-button", "is-active" ]
+    else
+      [ "tab-button" ]
+
+tabPanel :: forall action m. AppState -> H.ComponentHTML action () m
+tabPanel state = case state.activeTab of
+  ConnectTab -> connectPanel state
+  TokensTab -> tokensPanel state
+  FactsTab -> factsPanel state
+  EndTab -> endPanel state
+
+connectPanel :: forall action m. AppState -> H.ComponentHTML action () m
+connectPanel state =
+  panelLayout "Connect" "Wallet session"
+    [ fieldLine "Session" (walletStatusLabel state.walletSession.status)
+    , fieldLine "Network" (maybeText state.walletSession.network)
+    , fieldLine "Address" (maybeText state.walletSession.address)
+    , HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ inertButton "Connect wallet"
+        , inertButton "Refresh"
+        ]
+    ]
+
+tokensPanel :: forall action m. AppState -> H.ComponentHTML action () m
+tokensPanel state =
+  panelLayout "Tokens" "Token registry"
+    [ fieldLine "Token list" (remoteStatus state.tokens)
+    , fieldLine "Selected token" (selectedTokenLabel state.selectedToken)
+    , HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ inertButton "Load tokens"
+        , inertButton "Register token"
+        ]
+    ]
+
+factsPanel :: forall action m. AppState -> H.ComponentHTML action () m
+factsPanel state =
+  panelLayout "Facts" "Selected token facts"
+    [ fieldLine "Token" (selectedTokenLabel state.selectedToken)
+    , fieldLine "Facts" (remoteStatus state.facts)
+    , fieldLine "Trusted root" (remoteStatus state.trustedRoot)
+    , HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ inertButton "Load facts"
+        , inertButton "Verify proof"
+        ]
+    ]
+
+endPanel :: forall action m. AppState -> H.ComponentHTML action () m
+endPanel state =
+  panelLayout "End" "Cage lifecycle"
+    [ fieldLine "Token" (selectedTokenLabel state.selectedToken)
+    , fieldLine "Wallet" (walletStatusLabel state.walletSession.status)
+    , HH.div
+        [ HP.class_ (HH.ClassName "control-row") ]
+        [ inertButton "End cage"
+        ]
+    ]
+
+panelLayout
+  :: forall action m
+   . String
+  -> String
+  -> Array (H.ComponentHTML action () m)
+  -> H.ComponentHTML action () m
+panelLayout title subtitle children =
+  HH.div
+    [ HP.class_ (HH.ClassName "panel-layout") ]
+    ( [ HH.div
+          [ HP.class_ (HH.ClassName "panel-heading") ]
+          [ HH.h2_ [ HH.text title ]
+          , HH.p_ [ HH.text subtitle ]
+          ]
+      ]
+        <> children
+    )
+
+fieldLine :: forall action m. String -> String -> H.ComponentHTML action () m
+fieldLine label value =
+  HH.div
+    [ HP.class_ (HH.ClassName "field-line") ]
+    [ HH.span_ [ HH.text label ]
+    , HH.strong_ [ HH.text value ]
+    ]
+
+statusPill :: forall action m. String -> String -> H.ComponentHTML action () m
+statusPill label value =
+  HH.div
+    [ HP.class_ (HH.ClassName "status-pill") ]
+    [ HH.span_ [ HH.text label ]
+    , HH.strong_ [ HH.text value ]
+    ]
+
+inertButton :: forall action m. String -> H.ComponentHTML action () m
+inertButton label =
+  HH.button
+    [ HP.type_ HP.ButtonButton
+    , HP.disabled true
+    , HP.class_ (HH.ClassName "inert-button")
+    ]
+    [ HH.text label ]
+
+walletStatusLabel :: WalletStatus -> String
+walletStatusLabel = case _ of
+  WalletDisconnected -> "Not connected"
+  WalletConnecting -> "Connecting"
+  WalletConnected -> "Connected"
+
+selectedTokenLabel :: Maybe TokenId -> String
+selectedTokenLabel = case _ of
+  Nothing -> "None"
+  Just (TokenId tokenId) -> tokenId
+
+maybeText :: Maybe String -> String
+maybeText = case _ of
+  Nothing -> "Unavailable"
+  Just value -> value

--- a/src/MPFS/App/Wallet.purs
+++ b/src/MPFS/App/Wallet.purs
@@ -1,0 +1,172 @@
+module MPFS.App.Wallet
+  ( ConnectedWalletDetails
+  , disconnectWallet
+  , failWalletConnection
+  , failWalletDiscovery
+  , finishWalletConnection
+  , finishWalletDiscovery
+  , finishWalletRefresh
+  , setWalletRuntime
+  , startWalletConnection
+  , startWalletDiscovery
+  , unsupportedNetworkMessage
+  ) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Maybe (Maybe(..), fromMaybe)
+import Halogen.Query.HalogenM (SubscriptionId)
+import MPFS.App.State (AppState, WalletStatus(..))
+import MPFS.UI.Remote (Remote(..))
+import MPFS.Wallet.Cip30 (WalletApi, WalletInfo)
+
+type ConnectedWalletDetails =
+  { networkId :: Int
+  , usedAddresses :: Array String
+  , changeAddress :: String
+  , lovelace :: Maybe String
+  }
+
+startWalletDiscovery :: AppState -> AppState
+startWalletDiscovery state =
+  state
+    { walletSession =
+        state.walletSession
+          { wallets = Loading
+          , feedback = Nothing
+          }
+    }
+
+finishWalletDiscovery :: Array WalletInfo -> AppState -> AppState
+finishWalletDiscovery wallets state =
+  state
+    { walletSession =
+        state.walletSession
+          { wallets = Success wallets
+          , feedback =
+              if Array.null wallets then
+                Just "No CIP-30 wallet found."
+              else
+                Nothing
+          }
+    }
+
+failWalletDiscovery :: String -> AppState -> AppState
+failWalletDiscovery message state =
+  state
+    { walletSession =
+        state.walletSession
+          { wallets = Failure message
+          , feedback = Just message
+          }
+    }
+
+startWalletConnection :: WalletInfo -> AppState -> AppState
+startWalletConnection info state =
+  state
+    { walletSession =
+        state.walletSession
+          { status = WalletConnecting
+          , walletKey = Just info.key
+          , walletName = Just info.name
+          , networkId = Nothing
+          , network = Nothing
+          , selectedAddress = Nothing
+          , changeAddress = Nothing
+          , usedAddresses = []
+          , lovelace = Nothing
+          , feedback = Nothing
+          , api = Nothing
+          , subscriptionId = Nothing
+          }
+    }
+
+finishWalletConnection
+  :: WalletInfo -> ConnectedWalletDetails -> AppState -> AppState
+finishWalletConnection info details state =
+  if details.networkId == 0 then
+    state
+      { walletSession =
+          state.walletSession
+            { status = WalletConnected
+            , walletKey = Just info.key
+            , walletName = Just info.name
+            , networkId = Just details.networkId
+            , network = Just preprodNetworkLabel
+            , selectedAddress = Just (selectedAddress details)
+            , changeAddress = Just details.changeAddress
+            , usedAddresses = details.usedAddresses
+            , lovelace = details.lovelace
+            , feedback = Just ("Connected to " <> info.name <> ".")
+            }
+      }
+  else
+    failWalletConnection unsupportedNetworkMessage state
+
+finishWalletRefresh :: ConnectedWalletDetails -> AppState -> AppState
+finishWalletRefresh details state =
+  case state.walletSession.walletKey, state.walletSession.walletName of
+    Just key, Just name ->
+      finishWalletConnection { key, name, icon: "" } details state
+    _, _ ->
+      failWalletConnection "Connect a wallet first." state
+
+failWalletConnection :: String -> AppState -> AppState
+failWalletConnection message state =
+  state
+    { walletSession =
+        state.walletSession
+          { status = WalletDisconnected
+          , networkId = Nothing
+          , network = Nothing
+          , selectedAddress = Nothing
+          , changeAddress = Nothing
+          , usedAddresses = []
+          , lovelace = Nothing
+          , feedback = Just message
+          , api = Nothing
+          , subscriptionId = Nothing
+          }
+    }
+
+setWalletRuntime
+  :: Maybe WalletApi -> Maybe SubscriptionId -> AppState -> AppState
+setWalletRuntime api subscriptionId state =
+  state
+    { walletSession =
+        state.walletSession
+          { api = api
+          , subscriptionId = subscriptionId
+          }
+    }
+
+disconnectWallet :: AppState -> AppState
+disconnectWallet state =
+  state
+    { walletSession =
+        state.walletSession
+          { status = WalletDisconnected
+          , walletKey = Nothing
+          , walletName = Nothing
+          , networkId = Nothing
+          , network = Nothing
+          , selectedAddress = Nothing
+          , changeAddress = Nothing
+          , usedAddresses = []
+          , lovelace = Nothing
+          , feedback = Just "Wallet disconnected."
+          , api = Nothing
+          , subscriptionId = Nothing
+          }
+    }
+
+selectedAddress :: ConnectedWalletDetails -> String
+selectedAddress details =
+  fromMaybe details.changeAddress (Array.head details.usedAddresses)
+
+preprodNetworkLabel :: String
+preprodNetworkLabel = "preprod/testnet"
+
+unsupportedNetworkMessage :: String
+unsupportedNetworkMessage = "Switch the wallet to preprod before connecting."

--- a/src/MPFS/App/Write.purs
+++ b/src/MPFS/App/Write.purs
@@ -1,0 +1,212 @@
+module MPFS.App.Write
+  ( RefreshTarget(..)
+  , WriteForms
+  , WriteOperation(..)
+  , WriteStatus(..)
+  , failWrite
+  , initialWriteForms
+  , operationNeedsSelectedToken
+  , refreshPlanAfterSubmit
+  , requestIdOf
+  , setDeleteValue
+  , setDeleteKey
+  , setInsertKey
+  , setInsertValue
+  , setUpdateKey
+  , setUpdateNewValue
+  , setUpdateOldValue
+  , submittedWrite
+  , toggleRequestSelection
+  , validatePrerequisites
+  ) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import MPFS.Client.Types (PendingRequest)
+import MPFS.Types (RequestId(..), TokenId, UnsignedTxCbor)
+
+data WriteStatus
+  = WriteIdle
+  | WriteBuilding
+  | WriteBuilt UnsignedTxCbor
+  | WriteSigning UnsignedTxCbor
+  | WriteAssembling UnsignedTxCbor String
+  | WriteSubmitting UnsignedTxCbor String String
+  | WriteSubmitted UnsignedTxCbor String String String
+  | WriteFailed String
+
+derive instance Eq WriteStatus
+
+instance Show WriteStatus where
+  show = case _ of
+    WriteIdle -> "WriteIdle"
+    WriteBuilding -> "WriteBuilding"
+    WriteBuilt unsigned -> "WriteBuilt " <> show unsigned
+    WriteSigning unsigned -> "WriteSigning " <> show unsigned
+    WriteAssembling unsigned witness ->
+      "WriteAssembling " <> show unsigned <> " " <> witness
+    WriteSubmitting unsigned witness signed ->
+      "WriteSubmitting " <> show unsigned <> " " <> witness <> " " <> signed
+    WriteSubmitted unsigned witness signed txId ->
+      "WriteSubmitted "
+        <> show unsigned
+        <> " "
+        <> witness
+        <> " "
+        <> signed
+        <> " "
+        <> txId
+    WriteFailed message -> "WriteFailed " <> message
+
+type WriteForms =
+  { insertKey :: String
+  , insertValue :: String
+  , updateKey :: String
+  , updateOldValue :: String
+  , updateNewValue :: String
+  , deleteKey :: String
+  , deleteValue :: String
+  }
+
+data WriteOperation
+  = WriteRegisterToken
+  | WriteInsertFact
+  | WriteUpdateFact
+  | WriteDeleteFact
+  | WriteRetractRequest
+  | WriteRejectExpired
+  | WriteUpdateToken
+  | WriteEndCage
+
+derive instance Eq WriteOperation
+
+instance Show WriteOperation where
+  show = case _ of
+    WriteRegisterToken -> "WriteRegisterToken"
+    WriteInsertFact -> "WriteInsertFact"
+    WriteUpdateFact -> "WriteUpdateFact"
+    WriteDeleteFact -> "WriteDeleteFact"
+    WriteRetractRequest -> "WriteRetractRequest"
+    WriteRejectExpired -> "WriteRejectExpired"
+    WriteUpdateToken -> "WriteUpdateToken"
+    WriteEndCage -> "WriteEndCage"
+
+data RefreshTarget
+  = RefreshTokens
+  | RefreshTokenFacts TokenId
+  | RefreshTokenState TokenId
+  | RefreshPendingRequests TokenId
+
+derive instance Eq RefreshTarget
+
+instance Show RefreshTarget where
+  show = case _ of
+    RefreshTokens -> "RefreshTokens"
+    RefreshTokenFacts token -> "RefreshTokenFacts " <> show token
+    RefreshTokenState token -> "RefreshTokenState " <> show token
+    RefreshPendingRequests token -> "RefreshPendingRequests " <> show token
+
+initialWriteForms :: WriteForms
+initialWriteForms =
+  { insertKey: ""
+  , insertValue: ""
+  , updateKey: ""
+  , updateOldValue: ""
+  , updateNewValue: ""
+  , deleteKey: ""
+  , deleteValue: ""
+  }
+
+submittedWrite :: UnsignedTxCbor -> String -> String -> String -> WriteStatus
+submittedWrite = WriteSubmitted
+
+failWrite :: forall r. String -> { writeStatus :: WriteStatus | r } -> { writeStatus :: WriteStatus | r }
+failWrite message state = state { writeStatus = WriteFailed message }
+
+validatePrerequisites
+  :: forall r wr
+   . WriteOperation
+  -> { selectedToken :: Maybe TokenId
+     , walletSession :: { selectedAddress :: Maybe String | wr }
+     | r
+     }
+  -> Either String Unit
+validatePrerequisites operation state
+  | state.walletSession.selectedAddress == Nothing =
+      Left "Connect a wallet first."
+  | operationNeedsSelectedToken operation && state.selectedToken == Nothing =
+      Left "Select a token first."
+  | otherwise =
+      Right unit
+
+operationNeedsSelectedToken :: WriteOperation -> Boolean
+operationNeedsSelectedToken = case _ of
+  WriteRegisterToken -> false
+  _ -> true
+
+refreshPlanAfterSubmit :: Maybe TokenId -> Array RefreshTarget
+refreshPlanAfterSubmit = case _ of
+  Nothing -> [ RefreshTokens ]
+  Just token ->
+    [ RefreshTokens
+    , RefreshTokenFacts token
+    , RefreshTokenState token
+    , RefreshPendingRequests token
+    ]
+
+requestIdOf :: PendingRequest -> Maybe RequestId
+requestIdOf request =
+  if request.request_id == "" then Nothing
+  else Just (RequestId request.request_id)
+
+toggleRequestSelection
+  :: forall r
+   . RequestId
+  -> { selectedRequestIds :: Array RequestId | r }
+  -> { selectedRequestIds :: Array RequestId | r }
+toggleRequestSelection requestId state =
+  state
+    { selectedRequestIds =
+        if Array.elem requestId state.selectedRequestIds then
+          Array.filter (_ /= requestId) state.selectedRequestIds
+        else
+          state.selectedRequestIds <> [ requestId ]
+    }
+
+setInsertKey
+  :: forall r. String -> { writeForms :: WriteForms | r } -> { writeForms :: WriteForms | r }
+setInsertKey value = updateForms \forms -> forms { insertKey = value }
+
+setInsertValue
+  :: forall r. String -> { writeForms :: WriteForms | r } -> { writeForms :: WriteForms | r }
+setInsertValue value = updateForms \forms -> forms { insertValue = value }
+
+setUpdateKey
+  :: forall r. String -> { writeForms :: WriteForms | r } -> { writeForms :: WriteForms | r }
+setUpdateKey value = updateForms \forms -> forms { updateKey = value }
+
+setUpdateOldValue
+  :: forall r. String -> { writeForms :: WriteForms | r } -> { writeForms :: WriteForms | r }
+setUpdateOldValue value = updateForms \forms -> forms { updateOldValue = value }
+
+setUpdateNewValue
+  :: forall r. String -> { writeForms :: WriteForms | r } -> { writeForms :: WriteForms | r }
+setUpdateNewValue value = updateForms \forms -> forms { updateNewValue = value }
+
+setDeleteKey
+  :: forall r. String -> { writeForms :: WriteForms | r } -> { writeForms :: WriteForms | r }
+setDeleteKey value = updateForms \forms -> forms { deleteKey = value }
+
+setDeleteValue
+  :: forall r. String -> { writeForms :: WriteForms | r } -> { writeForms :: WriteForms | r }
+setDeleteValue value = updateForms \forms -> forms { deleteValue = value }
+
+updateForms
+  :: forall r
+   . (WriteForms -> WriteForms)
+  -> { writeForms :: WriteForms | r }
+  -> { writeForms :: WriteForms | r }
+updateForms f state = state { writeForms = f state.writeForms }

--- a/src/MPFS/Cage.purs
+++ b/src/MPFS/Cage.purs
@@ -1,0 +1,32 @@
+-- | The cage transaction-builder boundary.
+module MPFS.Cage
+  ( CageHelpers
+  , CageResult
+  ) where
+
+import Data.Either (Either)
+import Effect.Aff (Aff)
+import MPFS.Types
+  ( CageConfig
+  , CageError
+  , Key
+  , RequestId
+  , TokenId
+  , UnsignedTxCbor
+  , Value
+  , WalletAddr
+  )
+
+type CageResult = Aff (Either CageError UnsignedTxCbor)
+
+type CageHelpers =
+  { registerToken :: WalletAddr -> CageConfig -> CageResult
+  , insertFact :: WalletAddr -> CageConfig -> TokenId -> Key -> Value -> CageResult
+  , updateFact ::
+      WalletAddr -> CageConfig -> TokenId -> Key -> Value -> Value -> CageResult
+  , deleteFact :: WalletAddr -> CageConfig -> TokenId -> Key -> Value -> CageResult
+  , retractRequest :: WalletAddr -> CageConfig -> TokenId -> RequestId -> CageResult
+  , rejectExpired :: WalletAddr -> CageConfig -> TokenId -> Array RequestId -> CageResult
+  , endCage :: WalletAddr -> CageConfig -> TokenId -> CageResult
+  , updateToken :: WalletAddr -> CageConfig -> TokenId -> Array RequestId -> CageResult
+  }

--- a/src/MPFS/Cage/Reactor.js
+++ b/src/MPFS/Cage/Reactor.js
@@ -1,0 +1,1 @@
+export { runCageReactorImpl } from "../MPFS.Reactor/foreign.js";

--- a/src/MPFS/Cage/Reactor.purs
+++ b/src/MPFS/Cage/Reactor.purs
@@ -1,0 +1,94 @@
+-- | Stdin/stdout bridge to the MPFS cage reactor.
+module MPFS.Cage.Reactor
+  ( ReactorResult
+  , buildDecodeEnvelope
+  , decodeTxOut
+  , parseCageTxOutput
+  , parseDecodedOutput
+  , parseSignedTxOutput
+  , runCageReactor
+  ) where
+
+import Prelude
+
+import Control.Promise (Promise, toAffE)
+import Data.Argonaut.Core (Json, fromObject, fromString, stringify)
+import Data.Argonaut.Parser (jsonParser)
+import Data.Array (head)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.String.CodeUnits as CU
+import Data.String.Common as String
+import Data.String.Pattern (Pattern(..))
+import Data.Tuple (Tuple(..))
+import Effect (Effect)
+import Effect.Aff (Aff)
+import Foreign.Object as Object
+import MPFS.Types (CageError(..))
+
+type ReactorResult =
+  { stdout :: String
+  , stderr :: String
+  , exitOk :: Boolean
+  }
+
+foreign import runCageReactorImpl :: String -> Effect (Promise ReactorResult)
+
+runCageReactor :: String -> Aff ReactorResult
+runCageReactor = toAffE <<< runCageReactorImpl
+
+decodeTxOut :: String -> Aff (Either CageError Json)
+decodeTxOut txOutHex = do
+  result <- runCageReactor (buildDecodeEnvelope txOutHex)
+  pure (parseDecodedOutput result)
+
+buildDecodeEnvelope :: String -> String
+buildDecodeEnvelope txOutHex =
+  stringify
+    ( fromObject
+        ( Object.fromFoldable
+            [ Tuple "op" (fromString "decode")
+            , Tuple "tx_out" (fromString txOutHex)
+            ]
+        )
+    )
+
+parseDecodedOutput :: ReactorResult -> Either CageError Json
+parseDecodedOutput result
+  | not result.exitOk = Left (CageError (firstMessage result))
+  | otherwise =
+      case CU.stripPrefix (Pattern "decoded: ") (firstLine result.stdout) of
+        Just payload ->
+          case jsonParser (String.trim payload) of
+            Right json -> Right json
+            Left err -> Left (CageError ("decode parse: " <> err))
+        Nothing -> Left (CageError (firstMessage result))
+
+parseCageTxOutput :: ReactorResult -> Either CageError String
+parseCageTxOutput = parsePrefixedOutput "cage_tx: "
+
+parseSignedTxOutput :: ReactorResult -> Either CageError String
+parseSignedTxOutput = parsePrefixedOutput "signed_tx: "
+
+parsePrefixedOutput :: String -> ReactorResult -> Either CageError String
+parsePrefixedOutput prefix result
+  | not result.exitOk = Left (CageError (firstMessage result))
+  | otherwise =
+      case CU.stripPrefix (Pattern prefix) (firstLine result.stdout) of
+        Just hex | String.trim hex /= "" -> Right (String.trim hex)
+        _ -> Left (CageError (firstMessage result))
+
+firstMessage :: ReactorResult -> String
+firstMessage result =
+  let
+    err = String.trim result.stderr
+    out = String.trim result.stdout
+  in
+    if err /= "" then err
+    else if out /= "" then firstLine out
+    else "reactor returned no output"
+
+firstLine :: String -> String
+firstLine text =
+  String.trim
+    (fromMaybe text (head (String.split (Pattern "\n") text)))

--- a/src/MPFS/Cage/Wasm.js
+++ b/src/MPFS/Cage/Wasm.js
@@ -1,0 +1,4 @@
+export const encodeUtf8Hex = (text) =>
+  Array.from(new TextEncoder().encode(text))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");

--- a/src/MPFS/Cage/Wasm.purs
+++ b/src/MPFS/Cage/Wasm.purs
@@ -1,0 +1,229 @@
+-- | WASM-backed cage helper implementation.
+module MPFS.Cage.Wasm
+  ( assembleTx
+  , buildAssembleEnvelope
+  , buildBootEnvelope
+  , buildEndEnvelope
+  , buildRequestEnvelope
+  , wasmCageHelpers
+  ) where
+
+import Prelude
+
+import Data.Argonaut.Core (Json, fromNumber, fromObject, fromString, stringify)
+import Data.Bifunctor (lmap)
+import Data.Either (Either(..))
+import Data.Int (toNumber)
+import Data.Tuple (Tuple(..))
+import Effect.Aff (Aff)
+import Foreign.Object as Object
+import MPFS.Cage (CageHelpers, CageResult)
+import MPFS.Cage.Reactor
+  ( parseCageTxOutput
+  , parseSignedTxOutput
+  , runCageReactor
+  )
+import MPFS.Client (Client, ClientError)
+import MPFS.Types
+  ( CageConfig
+  , CageError(..)
+  , Key(..)
+  , RequestId(..)
+  , TokenId(..)
+  , TrustedRoot(..)
+  , UnsignedTxCbor(..)
+  , Value(..)
+  , WalletAddr(..)
+  )
+
+foreign import encodeUtf8Hex :: String -> String
+
+wasmCageHelpers :: Client -> CageHelpers
+wasmCageHelpers client =
+  { registerToken: registerToken client
+  , insertFact: insertFact client
+  , updateFact: updateFact client
+  , deleteFact: deleteFact client
+  , retractRequest: retractRequest client
+  , rejectExpired: rejectExpired client
+  , endCage: endCage client
+  , updateToken: updateToken client
+  }
+
+registerToken :: Client -> WalletAddr -> CageConfig -> CageResult
+registerToken client (WalletAddr address) cfg =
+  cageTxWithFacts client cfg "boot" (client.postBootFacts { address })
+
+insertFact :: Client -> WalletAddr -> CageConfig -> TokenId -> Key -> Value -> CageResult
+insertFact client (WalletAddr address) cfg (TokenId token) (Key key) (Value value) =
+  cageTxWithFacts client cfg "request_insert"
+    ( client.postInsertFacts
+        { token
+        , key: encodeUtf8Hex key
+        , value: encodeUtf8Hex value
+        , address
+        }
+    )
+
+updateFact
+  :: Client
+  -> WalletAddr
+  -> CageConfig
+  -> TokenId
+  -> Key
+  -> Value
+  -> Value
+  -> CageResult
+updateFact
+  client
+  (WalletAddr address)
+  cfg
+  (TokenId token)
+  (Key key)
+  (Value oldValue)
+  (Value newValue) =
+  cageTxWithFacts client cfg "request_update"
+    ( client.postUpdateFacts
+        { token
+        , key: encodeUtf8Hex key
+        , old_value: encodeUtf8Hex oldValue
+        , new_value: encodeUtf8Hex newValue
+        , address
+        }
+    )
+
+deleteFact :: Client -> WalletAddr -> CageConfig -> TokenId -> Key -> Value -> CageResult
+deleteFact client (WalletAddr address) cfg (TokenId token) (Key key) (Value value) =
+  cageTxWithFacts client cfg "request_delete"
+    ( client.postDeleteFacts
+        { token
+        , key: encodeUtf8Hex key
+        , value: encodeUtf8Hex value
+        , address
+        }
+    )
+
+retractRequest :: Client -> WalletAddr -> CageConfig -> TokenId -> RequestId -> CageResult
+retractRequest client (WalletAddr address) cfg _ (RequestId utxo) =
+  cageTxWithFacts client cfg "retract"
+    (client.postRetractFacts { utxo, address })
+
+rejectExpired
+  :: Client -> WalletAddr -> CageConfig -> TokenId -> Array RequestId -> CageResult
+rejectExpired client (WalletAddr address) cfg (TokenId token) requestIds =
+  cageTxWithFacts client cfg "reject"
+    ( client.postRejectFacts
+        { token, address, requests: requestIdStrings requestIds }
+    )
+
+endCage :: Client -> WalletAddr -> CageConfig -> TokenId -> CageResult
+endCage client (WalletAddr address) cfg (TokenId token) =
+  cageTxWithFacts client cfg "end"
+    (client.postEndFacts { token, address })
+
+updateToken
+  :: Client -> WalletAddr -> CageConfig -> TokenId -> Array RequestId -> CageResult
+updateToken client (WalletAddr address) cfg (TokenId token) requestIds =
+  cageTxWithFacts client cfg "update"
+    ( client.postUpdateRootFacts
+        { token, address, requests: requestIdStrings requestIds }
+    )
+
+assembleTx :: String -> String -> Aff (Either CageError String)
+assembleTx unsignedTx witnessSet = do
+  result <- runCageReactor (buildAssembleEnvelope unsignedTx witnessSet)
+  pure (parseSignedTxOutput result)
+
+cageTxWithFacts
+  :: Client
+  -> CageConfig
+  -> String
+  -> Aff (Either ClientError Json)
+  -> CageResult
+cageTxWithFacts client cfg op fetchFacts = do
+  eroot <- client.getTrustedRoot
+  ectx <- client.getEvalContext
+  efacts <- fetchFacts
+  case clientError eroot, clientError ectx, clientError efacts of
+    Left err, _, _ -> pure (Left err)
+    _, Left err, _ -> pure (Left err)
+    _, _, Left err -> pure (Left err)
+    Right root, Right evalContext, Right facts -> do
+      let
+        envelope =
+          if op == "boot" then buildBootEnvelope root evalContext cfg facts
+          else if op == "end" then buildEndEnvelope root evalContext cfg facts
+          else buildRequestEnvelope op root evalContext cfg facts
+      result <- runCageReactor envelope
+      pure (UnsignedTxCbor <$> parseCageTxOutput result)
+
+clientError :: forall a. Either ClientError a -> Either CageError a
+clientError = lmap (CageError <<< show)
+
+requestIdStrings :: Array RequestId -> Array String
+requestIdStrings = map \(RequestId requestId) -> requestId
+
+buildBootEnvelope :: TrustedRoot -> Json -> CageConfig -> Json -> String
+buildBootEnvelope root evalContext cfg facts =
+  stringify (buildEnvelope "boot" root evalContext cfg facts)
+
+buildEndEnvelope :: TrustedRoot -> Json -> CageConfig -> Json -> String
+buildEndEnvelope root evalContext cfg facts =
+  stringify (buildEnvelope "end" root evalContext cfg facts)
+
+buildRequestEnvelope :: String -> TrustedRoot -> Json -> CageConfig -> Json -> String
+buildRequestEnvelope op root evalContext cfg facts =
+  stringify (buildEnvelope op root evalContext cfg facts)
+
+buildAssembleEnvelope :: String -> String -> String
+buildAssembleEnvelope unsignedTx witnessSet =
+  stringify
+    ( obj
+        [ Tuple "op" (fromString "assemble")
+        , Tuple "unsigned_tx" (fromString unsignedTx)
+        , Tuple "witness_set" (fromString witnessSet)
+        ]
+    )
+
+buildEnvelope :: String -> TrustedRoot -> Json -> CageConfig -> Json -> Json
+buildEnvelope op (TrustedRoot trustedRoot) evalContext cfg facts =
+  obj
+    [ Tuple "op" (fromString op)
+    , Tuple "trusted_root" (fromString trustedRoot)
+    , Tuple "eval_context" evalContext
+    , Tuple "cage_config" (cageConfigJson cfg)
+    , Tuple "wallet_policy" walletPolicyJson
+    , Tuple "facts" facts
+    ]
+
+cageConfigJson :: CageConfig -> Json
+cageConfigJson cfg =
+  obj
+    [ Tuple "cage_script_bytes" (fromString cfg.cageScriptBytes)
+    , Tuple "request_script_bytes" (fromString cfg.requestScriptBytes)
+    , Tuple "default_process_time" (intJson cfg.defaultProcessTime)
+    , Tuple "default_retract_time" (intJson cfg.defaultRetractTime)
+    , Tuple "default_tip" (intJson cfg.defaultTip)
+    , Tuple "network" (fromString cfg.network)
+    ]
+
+walletPolicyJson :: Json
+walletPolicyJson =
+  obj
+    [ Tuple "max_fee" (fromNumber 10000000.0)
+    , Tuple "max_min_utxo_coin_per_byte" (fromNumber 10000.0)
+    , Tuple "max_ex_unit_prices"
+        ( obj
+            [ Tuple "price_memory" (fromNumber 1000000000000.0)
+            , Tuple "price_steps" (fromNumber 1000000000000.0)
+            , Tuple "pr_mem" (fromNumber 1000000000000.0)
+            , Tuple "pr_steps" (fromNumber 1000000000000.0)
+            ]
+        )
+    ]
+
+intJson :: Int -> Json
+intJson = fromNumber <<< toNumber
+
+obj :: Array (Tuple String Json) -> Json
+obj = fromObject <<< Object.fromFoldable

--- a/src/MPFS/Client.purs
+++ b/src/MPFS/Client.purs
@@ -6,6 +6,7 @@ module MPFS.Client
   , Client
   , decodeFactBody
   , decodeFactsBody
+  , decodeRequestsBody
   , decodeTokensBody
   , mkClient
   ) where
@@ -28,8 +29,10 @@ import Data.Array (null)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
+import Data.Traversable (traverse)
 import Effect.Aff (Aff)
 import Fetch (Method(..), fetch)
+import Foreign.Object as Object
 import MPFS.Client.Types
   ( BootBody
   , DeleteBody
@@ -146,7 +149,7 @@ mkClient baseUrl =
             <> key
         )
   , getTokenRequests: \tokenId ->
-      get
+      getWith decodeRequestsBody
         ( baseUrl <> "/tokens/" <> tokenId
             <> "/requests"
         )
@@ -230,6 +233,11 @@ decodeFactsBody body = do
   response :: FactsResponse <- decodeBody body
   pure response.facts
 
+decodeRequestsBody :: String -> Either ClientError (Array PendingRequest)
+decodeRequestsBody body = do
+  json <- lmap DecodeError (jsonParser body)
+  lmap (show >>> DecodeError) (decodeRequests json)
+
 decodeFactBody :: String -> Either ClientError Hex
 decodeFactBody body = do
   response :: FactResponse <- decodeBody body
@@ -260,6 +268,57 @@ decodeTxId :: Json -> Either JsonDecodeError Hex
 decodeTxId json = do
   top <- decodeJson json
   top .: "txId"
+
+decodeRequests :: Json -> Either JsonDecodeError (Array PendingRequest)
+decodeRequests json = do
+  top <- decodeJson json
+  mRequests <- top .:? "requests"
+  case mRequests of
+    Just requests ->
+      traverse decodePendingRequest requests
+    Nothing -> do
+      requests <- decodeJson json
+      traverse decodePendingRequest requests
+
+decodePendingRequest :: Json -> Either JsonDecodeError PendingRequest
+decodePendingRequest json = do
+  request <- decodeJson json
+  token <- request .: "token"
+  owner <- request .: "owner"
+  key <- request .: "key"
+  operation <- request .: "operation"
+  value <- request .:? "value"
+  fee <- request .: "fee"
+  submitted_at <- request .: "submitted_at"
+  request_id <- decodeRequestId request
+  pure
+    { token
+    , owner
+    , key
+    , operation
+    , value
+    , fee
+    , submitted_at
+    , request_id
+    }
+
+decodeRequestId :: Object.Object Json -> Either JsonDecodeError String
+decodeRequestId request = do
+  mSnake <- request .:? "request_id"
+  case mSnake of
+    Just requestId ->
+      pure requestId
+    Nothing -> do
+      mCamel <- request .:? "requestId"
+      case mCamel of
+        Just requestId ->
+          pure requestId
+        Nothing -> do
+          utxo <- request .: "utxo"
+          txIn <- utxo .: "tx_in"
+          txId <- txIn .: "tx_id"
+          txIx <- txIn .: "tx_ix"
+          pure (txId <> "#" <> show (txIx :: Int))
 
 get
   :: forall a

--- a/src/MPFS/Client.purs
+++ b/src/MPFS/Client.purs
@@ -10,11 +10,13 @@ module MPFS.Client
 
 import Prelude
 
-import Data.Argonaut.Core (stringify)
+import Data.Argonaut.Core (Json, stringify)
 import Data.Argonaut.Decode.Class
   ( class DecodeJson
   , decodeJson
   )
+import Data.Argonaut.Decode.Combinators ((.:), (.:?))
+import Data.Argonaut.Decode.Error (JsonDecodeError)
 import Data.Argonaut.Encode.Class
   ( class EncodeJson
   , encodeJson
@@ -23,6 +25,7 @@ import Data.Argonaut.Parser (jsonParser)
 import Data.Array (null)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff)
 import Fetch (Method(..), fetch)
 import MPFS.Client.Types
@@ -32,14 +35,18 @@ import MPFS.Client.Types
   , Hex
   , InsertBody
   , PendingRequest
+  , RejectBody
   , RetractBody
+  , RequestUpdateBody
   , StatusResponse
   , SubmitBody
   , TokenId
   , TokensResponse
   , TokenState
   , UpdateBody
+  , UpdateRootBody
   )
+import MPFS.Types (TrustedRoot(..))
 
 -- | Client error: HTTP or JSON decoding failure.
 data ClientError
@@ -79,6 +86,18 @@ type Client =
   , retract :: RetractBody -> Aff (Either ClientError Hex)
   , end :: EndBody -> Aff (Either ClientError Hex)
   , submit :: SubmitBody -> Aff (Either ClientError Hex)
+  , getTrustedRoot :: Aff (Either ClientError TrustedRoot)
+  , getEvalContext :: Aff (Either ClientError Json)
+  , postBootFacts :: BootBody -> Aff (Either ClientError Json)
+  , postInsertFacts :: InsertBody -> Aff (Either ClientError Json)
+  , postUpdateFacts :: RequestUpdateBody -> Aff (Either ClientError Json)
+  , postDeleteFacts :: DeleteBody -> Aff (Either ClientError Json)
+  , postRetractFacts ::
+      { utxo :: String, address :: Hex } -> Aff (Either ClientError Json)
+  , postRejectFacts :: RejectBody -> Aff (Either ClientError Json)
+  , postEndFacts :: EndBody -> Aff (Either ClientError Json)
+  , postUpdateRootFacts :: UpdateRootBody -> Aff (Either ClientError Json)
+  , submitSignedTx :: Hex -> Aff (Either ClientError Hex)
   , getUtxo ::
       Hex -> Int -> Aff (Either ClientError Hex)
   , getUtxoProof ::
@@ -132,6 +151,30 @@ mkClient baseUrl =
       post (baseUrl <> "/tx/end")
   , submit:
       post (baseUrl <> "/tx/submit")
+  , getTrustedRoot:
+      getWith decodeTrustedRootBody (baseUrl <> "/status")
+  , getEvalContext:
+      getJson (baseUrl <> "/eval-context")
+  , postBootFacts:
+      postJson (baseUrl <> "/facts/boot")
+  , postInsertFacts:
+      postJson (baseUrl <> "/facts/request/insert")
+  , postUpdateFacts:
+      postJson (baseUrl <> "/facts/request/update")
+  , postDeleteFacts:
+      postJson (baseUrl <> "/facts/request/delete")
+  , postRetractFacts:
+      postJson (baseUrl <> "/facts/retract")
+  , postRejectFacts:
+      postJson (baseUrl <> "/facts/reject")
+  , postEndFacts:
+      postJson (baseUrl <> "/facts/end")
+  , postUpdateRootFacts:
+      postJson (baseUrl <> "/facts/update")
+  , submitSignedTx: \signedTxCbor ->
+      postWith decodeTxIdBody
+        (baseUrl <> "/submit")
+        { signedTxCbor }
   , getUtxo: \txId txIx ->
       get
         ( baseUrl <> "/utxo/" <> txId
@@ -169,6 +212,32 @@ decodeTokensBody body = do
     Left $ DecodeError
       "Cannot derive token ids from tokens.entries[].txout_cbor"
 
+decodeTrustedRootBody :: String -> Either ClientError TrustedRoot
+decodeTrustedRootBody body = do
+  json <- lmap DecodeError (jsonParser body)
+  lmap (show >>> DecodeError) (decodeTrustedRoot json)
+
+decodeTrustedRoot :: Json -> Either JsonDecodeError TrustedRoot
+decodeTrustedRoot json = do
+  top <- decodeJson json
+  mRoot <- top .:? "utxo_root"
+  case mRoot of
+    Just root -> pure (TrustedRoot root)
+    Nothing -> do
+      snapshot <- top .: "snapshot"
+      root <- snapshot .: "utxo_root"
+      pure (TrustedRoot root)
+
+decodeTxIdBody :: String -> Either ClientError Hex
+decodeTxIdBody body = do
+  json <- lmap DecodeError (jsonParser body)
+  lmap (show >>> DecodeError) (decodeTxId json)
+
+decodeTxId :: Json -> Either JsonDecodeError Hex
+decodeTxId json = do
+  top <- decodeJson json
+  top .: "txId"
+
 get
   :: forall a
    . DecodeJson a
@@ -189,6 +258,12 @@ getWith decoder url = do
     if response.ok then decoder body
     else Left $ HttpError response.status body
 
+getJson :: String -> Aff (Either ClientError Json)
+getJson = getWith decodeJsonBody
+
+decodeJsonBody :: String -> Either ClientError Json
+decodeJsonBody = jsonParser >>> lmap DecodeError
+
 post
   :: forall req a
    . EncodeJson req
@@ -197,6 +272,16 @@ post
   -> req
   -> Aff (Either ClientError a)
 post url reqBody = do
+  postWith decodeBody url reqBody
+
+postWith
+  :: forall req a
+   . EncodeJson req
+  => (String -> Either ClientError a)
+  -> String
+  -> req
+  -> Aff (Either ClientError a)
+postWith decoder url reqBody = do
   response <- fetch url
     { method: POST
     , body: stringify (encodeJson reqBody)
@@ -205,5 +290,13 @@ post url reqBody = do
     }
   body <- response.text
   pure
-    if response.ok then decodeBody body
+    if response.ok then decoder body
     else Left $ HttpError response.status body
+
+postJson
+  :: forall req
+   . EncodeJson req
+  => String
+  -> req
+  -> Aff (Either ClientError Json)
+postJson = postWith decodeJsonBody

--- a/src/MPFS/Client.purs
+++ b/src/MPFS/Client.purs
@@ -4,6 +4,8 @@
 module MPFS.Client
   ( ClientError(..)
   , Client
+  , decodeFactBody
+  , decodeFactsBody
   , decodeTokensBody
   , mkClient
   ) where
@@ -32,6 +34,9 @@ import MPFS.Client.Types
   ( BootBody
   , DeleteBody
   , EndBody
+  , FactResponse
+  , FactEntry
+  , FactsResponse
   , Hex
   , InsertBody
   , PendingRequest
@@ -71,6 +76,9 @@ type Client =
       TokenId
       -> Hex
       -> Aff (Either ClientError Hex)
+  , getTokenFacts ::
+      TokenId
+      -> Aff (Either ClientError (Array FactEntry))
   , getTokenProof ::
       TokenId
       -> Hex
@@ -121,10 +129,15 @@ mkClient baseUrl =
             <> "/root"
         )
   , getTokenFact: \tokenId key ->
-      get
+      getWith decodeFactBody
         ( baseUrl <> "/tokens/" <> tokenId
             <> "/facts/"
             <> key
+        )
+  , getTokenFacts: \tokenId ->
+      getWith decodeFactsBody
+        ( baseUrl <> "/tokens/" <> tokenId
+            <> "/facts"
         )
   , getTokenProof: \tokenId key ->
       get
@@ -211,6 +224,16 @@ decodeTokensBody body = do
   else
     Left $ DecodeError
       "Cannot derive token ids from tokens.entries[].txout_cbor"
+
+decodeFactsBody :: String -> Either ClientError (Array FactEntry)
+decodeFactsBody body = do
+  response :: FactsResponse <- decodeBody body
+  pure response.facts
+
+decodeFactBody :: String -> Either ClientError Hex
+decodeFactBody body = do
+  response :: FactResponse <- decodeBody body
+  pure response.value
 
 decodeTrustedRootBody :: String -> Either ClientError TrustedRoot
 decodeTrustedRootBody body = do

--- a/src/MPFS/Client/Types.purs
+++ b/src/MPFS/Client/Types.purs
@@ -10,6 +10,9 @@ module MPFS.Client.Types
   , StatusResponse
   , TokenState
   , PendingRequest
+  , FactEntry
+  , FactsResponse
+  , FactResponse
   , BootBody
   , InsertBody
   , DeleteBody
@@ -73,6 +76,22 @@ type PendingRequest =
   , value :: Maybe Hex
   , fee :: Number
   , submitted_at :: Number
+  }
+
+-- | @GET /tokens/:id/facts@ element.
+type FactEntry =
+  { key :: Hex
+  , value :: Hex
+  }
+
+-- | @GET /tokens/:id/facts@ response.
+type FactsResponse =
+  { facts :: Array FactEntry
+  }
+
+-- | @GET /tokens/:id/facts/:key@ response.
+type FactResponse =
+  { value :: Hex
   }
 
 -- | @POST /tx/boot@ body.

--- a/src/MPFS/Client/Types.purs
+++ b/src/MPFS/Client/Types.purs
@@ -17,6 +17,9 @@ module MPFS.Client.Types
   , RetractBody
   , EndBody
   , SubmitBody
+  , RejectBody
+  , RequestUpdateBody
+  , UpdateRootBody
   ) where
 
 import Data.Maybe (Maybe)
@@ -87,6 +90,16 @@ type InsertBody =
 type DeleteBody =
   { token :: TokenId
   , key :: Hex
+  , value :: Hex
+  , address :: Hex
+  }
+
+-- | @POST /facts/request/update@ body.
+type RequestUpdateBody =
+  { token :: TokenId
+  , key :: Hex
+  , old_value :: Hex
+  , new_value :: Hex
   , address :: Hex
   }
 
@@ -106,6 +119,20 @@ type RetractBody =
 -- | @POST /tx/end@ body.
 type EndBody =
   { token :: TokenId
+  , address :: Hex
+  }
+
+-- | @POST /facts/reject@ body.
+type RejectBody =
+  { token :: TokenId
+  , requests :: Array String
+  , address :: Hex
+  }
+
+-- | @POST /facts/update@ body.
+type UpdateRootBody =
+  { token :: TokenId
+  , requests :: Array String
   , address :: Hex
   }
 

--- a/src/MPFS/Client/Types.purs
+++ b/src/MPFS/Client/Types.purs
@@ -76,6 +76,7 @@ type PendingRequest =
   , value :: Maybe Hex
   , fee :: Number
   , submitted_at :: Number
+  , request_id :: String
   }
 
 -- | @GET /tokens/:id/facts@ element.

--- a/src/MPFS/Types.purs
+++ b/src/MPFS/Types.purs
@@ -1,0 +1,77 @@
+-- | Shared MPFS domain types used by the browser logic boundary.
+module MPFS.Types
+  ( WalletAddr(..)
+  , TokenId(..)
+  , Key(..)
+  , Value(..)
+  , RequestId(..)
+  , UnsignedTxCbor(..)
+  , TrustedRoot(..)
+  , CageConfig
+  , CageError(..)
+  , cageErrorMessage
+  ) where
+
+import Prelude
+
+-- | A wallet payment address as surfaced by CIP-30.
+newtype WalletAddr = WalletAddr String
+
+derive instance Eq WalletAddr
+derive newtype instance Show WalletAddr
+
+-- | An MPFS token identifier.
+newtype TokenId = TokenId String
+
+derive instance Eq TokenId
+derive newtype instance Show TokenId
+
+-- | A fact key.
+newtype Key = Key String
+
+derive instance Eq Key
+derive newtype instance Show Key
+
+-- | A fact value.
+newtype Value = Value String
+
+derive instance Eq Value
+derive newtype instance Show Value
+
+-- | A pending request identifier (`txid#ix`).
+newtype RequestId = RequestId String
+
+derive instance Eq RequestId
+derive newtype instance Show RequestId
+
+-- | A hex-encoded unsigned transaction CBOR value.
+newtype UnsignedTxCbor = UnsignedTxCbor String
+
+derive instance Eq UnsignedTxCbor
+derive newtype instance Show UnsignedTxCbor
+
+-- | A hex-encoded trusted MPFS root.
+newtype TrustedRoot = TrustedRoot String
+
+derive instance Eq TrustedRoot
+derive newtype instance Show TrustedRoot
+
+-- | Client-side cage transaction configuration.
+type CageConfig =
+  { cageScriptBytes :: String
+  , requestScriptBytes :: String
+  , cfgScriptHash :: String
+  , defaultProcessTime :: Int
+  , defaultRetractTime :: Int
+  , defaultTip :: Int
+  , network :: String
+  }
+
+-- | An error returned by the cage reactor boundary.
+newtype CageError = CageError String
+
+derive instance Eq CageError
+derive newtype instance Show CageError
+
+cageErrorMessage :: CageError -> String
+cageErrorMessage (CageError msg) = msg

--- a/src/MPFS/UI/Remote.purs
+++ b/src/MPFS/UI/Remote.purs
@@ -1,0 +1,28 @@
+module MPFS.UI.Remote
+  ( Remote(..)
+  , remoteStatus
+  ) where
+
+import Prelude
+
+data Remote a
+  = NotAsked
+  | Loading
+  | Failure String
+  | Success a
+
+derive instance Eq a => Eq (Remote a)
+
+instance Show a => Show (Remote a) where
+  show = case _ of
+    NotAsked -> "NotAsked"
+    Loading -> "Loading"
+    Failure msg -> "(Failure " <> show msg <> ")"
+    Success value -> "(Success " <> show value <> ")"
+
+remoteStatus :: forall a. Remote a -> String
+remoteStatus = case _ of
+  NotAsked -> "Not loaded"
+  Loading -> "Loading"
+  Failure _ -> "Error"
+  Success _ -> "Ready"

--- a/src/MPFS/Wallet/Cip30.js
+++ b/src/MPFS/Wallet/Cip30.js
@@ -1,0 +1,146 @@
+export const _availableWallets = () => {
+  const cardano =
+    (typeof window !== "undefined" && window.cardano) || {};
+  const out = [];
+  for (const key of Object.keys(cardano)) {
+    const wallet = cardano[key];
+    if (
+      wallet &&
+      typeof wallet.enable === "function" &&
+      typeof wallet.name === "string"
+    ) {
+      out.push({ key, name: wallet.name, icon: wallet.icon || "" });
+    }
+  }
+  return out;
+};
+
+export const _enable = (key) => () => window.cardano[key].enable();
+
+export const _getNetworkId = (api) => () => api.getNetworkId();
+export const _getUsedAddresses = (api) => () => api.getUsedAddresses();
+export const _getChangeAddress = (api) => () => api.getChangeAddress();
+export const _getBalance = (api) => () => api.getBalance();
+
+export const _subscribeAccountChanges = (api) => (handler) => () => {
+  let cancelled = false;
+  const safeHandler = () => {
+    if (!cancelled) handler();
+  };
+  const cleanups = [
+    subscribeWalletEvent(api, "accountChange", safeHandler),
+    subscribeWalletEvent(api, "networkChange", safeHandler),
+    subscribeWalletEvent(api, "accountsChanged", safeHandler),
+    subscribeWalletEvent(api, "chainChanged", safeHandler),
+  ].filter(Boolean);
+
+  return () => {
+    cancelled = true;
+    for (const cleanup of cleanups) {
+      try {
+        cleanup();
+      } catch (_e) {
+        // Ignore wallet cleanup errors while leaving the account.
+      }
+    }
+  };
+};
+
+export const _signTx = (api) => (tx) => (partial) => () =>
+  api.signTx(tx, partial);
+
+export const _submitTx = (api) => (tx) => () => api.submitTx(tx);
+
+export const _ownerKeyHashOfAddress = (addressHex) => {
+  const hex = String(addressHex || "").replace(/\s+/g, "").toLowerCase();
+  if (!/^[0-9a-f]+$/.test(hex) || hex.length < 58) return null;
+
+  const header = parseInt(hex.slice(0, 2), 16);
+  const addressType = header >> 4;
+
+  if ([0, 2, 4, 6].includes(addressType)) {
+    return hex.slice(2, 58);
+  }
+  return null;
+};
+
+export const _coinOfBalance = (hex) => {
+  try {
+    const bytes = hexToBytes(hex);
+    let offset = 0;
+    if ((bytes[0] & 0xe0) === 0x80) offset = 1;
+    if ((bytes[offset] & 0xe0) !== 0x00) return null;
+    const value = readUint(bytes, offset);
+    return value === null ? null : value.toString();
+  } catch (_e) {
+    return null;
+  }
+};
+
+function subscribeWalletEvent(api, eventName, handler) {
+  const targets = [api && api.experimental, api].filter(Boolean);
+  for (const target of targets) {
+    const cleanup = trySubscribeTarget(target, eventName, handler);
+    if (cleanup) return cleanup;
+  }
+  return null;
+}
+
+function trySubscribeTarget(target, eventName, handler) {
+  try {
+    if (typeof target.on === "function") {
+      const result = target.on(eventName, handler);
+      if (typeof result === "function") return result;
+      if (typeof target.off === "function") {
+        return () => target.off(eventName, handler);
+      }
+      if (typeof target.removeListener === "function") {
+        return () => target.removeListener(eventName, handler);
+      }
+    }
+
+    const method =
+      "on" + eventName.charAt(0).toUpperCase() + eventName.slice(1);
+    if (typeof target[method] === "function") {
+      const result = target[method](handler);
+      if (typeof result === "function") return result;
+      return () => {};
+    }
+  } catch (_e) {
+    return null;
+  }
+  return null;
+}
+
+function hexToBytes(hex) {
+  const bytes = [];
+  for (let i = 0; i + 1 < hex.length; i += 2) {
+    bytes.push(parseInt(hex.slice(i, i + 2), 16));
+  }
+  return bytes;
+}
+
+function readUint(bytes, offset) {
+  const info = bytes[offset] & 0x1f;
+  if (info < 24) return BigInt(info);
+  if (info === 24) return BigInt(bytes[offset + 1]);
+  if (info === 25) {
+    return (BigInt(bytes[offset + 1]) << 8n) |
+      BigInt(bytes[offset + 2]);
+  }
+  if (info === 26) {
+    let value = 0n;
+    for (let i = 1; i <= 4; i++) {
+      value = (value << 8n) | BigInt(bytes[offset + i]);
+    }
+    return value;
+  }
+  if (info === 27) {
+    let value = 0n;
+    for (let i = 1; i <= 8; i++) {
+      value = (value << 8n) | BigInt(bytes[offset + i]);
+    }
+    return value;
+  }
+  return null;
+}

--- a/src/MPFS/Wallet/Cip30.purs
+++ b/src/MPFS/Wallet/Cip30.purs
@@ -1,0 +1,79 @@
+-- | CIP-30 wallet connector.
+module MPFS.Wallet.Cip30
+  ( WalletApi
+  , WalletInfo
+  , availableWallets
+  , enable
+  , getNetworkId
+  , getUsedAddresses
+  , getChangeAddress
+  , getBalance
+  , subscribeAccountChanges
+  , ownerKeyHashOfAddress
+  , lovelaceOfBalance
+  , signTx
+  , submitTx
+  , networkName
+  ) where
+
+import Prelude
+
+import Control.Promise (Promise, toAffE)
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Effect (Effect)
+import Effect.Aff (Aff)
+
+foreign import data WalletApi :: Type
+
+type WalletInfo = { key :: String, name :: String, icon :: String }
+
+foreign import _availableWallets :: Effect (Array WalletInfo)
+foreign import _enable :: String -> Effect (Promise WalletApi)
+foreign import _getNetworkId :: WalletApi -> Effect (Promise Int)
+foreign import _getUsedAddresses :: WalletApi -> Effect (Promise (Array String))
+foreign import _getChangeAddress :: WalletApi -> Effect (Promise String)
+foreign import _getBalance :: WalletApi -> Effect (Promise String)
+foreign import _subscribeAccountChanges :: WalletApi -> Effect Unit -> Effect (Effect Unit)
+foreign import _ownerKeyHashOfAddress :: String -> Nullable String
+foreign import _signTx :: WalletApi -> String -> Boolean -> Effect (Promise String)
+foreign import _submitTx :: WalletApi -> String -> Effect (Promise String)
+foreign import _coinOfBalance :: String -> Nullable String
+
+availableWallets :: Effect (Array WalletInfo)
+availableWallets = _availableWallets
+
+enable :: String -> Aff WalletApi
+enable key = toAffE (_enable key)
+
+getNetworkId :: WalletApi -> Aff Int
+getNetworkId api = toAffE (_getNetworkId api)
+
+getUsedAddresses :: WalletApi -> Aff (Array String)
+getUsedAddresses api = toAffE (_getUsedAddresses api)
+
+getChangeAddress :: WalletApi -> Aff String
+getChangeAddress api = toAffE (_getChangeAddress api)
+
+getBalance :: WalletApi -> Aff String
+getBalance api = toAffE (_getBalance api)
+
+subscribeAccountChanges :: WalletApi -> Effect Unit -> Effect (Effect Unit)
+subscribeAccountChanges = _subscribeAccountChanges
+
+ownerKeyHashOfAddress :: String -> Maybe String
+ownerKeyHashOfAddress = toMaybe <<< _ownerKeyHashOfAddress
+
+lovelaceOfBalance :: String -> Maybe String
+lovelaceOfBalance = toMaybe <<< _coinOfBalance
+
+signTx :: WalletApi -> String -> Boolean -> Aff String
+signTx api tx partial = toAffE (_signTx api tx partial)
+
+submitTx :: WalletApi -> String -> Aff String
+submitTx api tx = toAffE (_submitTx api tx)
+
+networkName :: Int -> String
+networkName 1 = "mainnet"
+networkName 0 = "testnet"
+networkName n = "network " <> show n

--- a/test/Test/AppSpec.purs
+++ b/test/Test/AppSpec.purs
@@ -1,0 +1,32 @@
+module Test.AppSpec (spec) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Maybe (Maybe(..))
+import MPFS.App.State (defaultState, selectTab)
+import MPFS.App.Tab (AppTab(..), allTabs, defaultTab, tabLabel, tabSlug, tabFromSlug)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS App Shell" do
+  it "defines the four routed tabs in workbench order" do
+    allTabs `shouldEqual` [ ConnectTab, TokensTab, FactsTab, EndTab ]
+    Array.length allTabs `shouldEqual` 4
+
+  it "exposes deterministic tab labels and slugs" do
+    map tabLabel allTabs
+      `shouldEqual` [ "Connect", "Tokens", "Facts", "End" ]
+    map tabSlug allTabs
+      `shouldEqual` [ "connect", "tokens", "facts", "end" ]
+
+  it "uses Connect as the default app selection" do
+    defaultTab `shouldEqual` ConnectTab
+    defaultState.activeTab `shouldEqual` ConnectTab
+
+  it "looks up and selects tabs without changing unrelated state" do
+    tabFromSlug "facts" `shouldEqual` Just FactsTab
+    tabFromSlug "missing" `shouldEqual` Nothing
+    (selectTab EndTab defaultState).activeTab `shouldEqual` EndTab
+    (selectTab EndTab defaultState).selectedToken `shouldEqual` defaultState.selectedToken

--- a/test/Test/AppWalletSpec.purs
+++ b/test/Test/AppWalletSpec.purs
@@ -1,0 +1,121 @@
+module Test.AppWalletSpec (spec) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import MPFS.App.State (WalletStatus(..), defaultState)
+import MPFS.App.Wallet
+  ( ConnectedWalletDetails
+  , disconnectWallet
+  , failWalletDiscovery
+  , finishWalletConnection
+  , finishWalletDiscovery
+  , startWalletConnection
+  , startWalletDiscovery
+  )
+import MPFS.Types (TokenId(..))
+import MPFS.UI.Remote (Remote(..))
+import MPFS.Wallet.Cip30 (WalletInfo)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS App Wallet" do
+  it "tracks wallet discovery loading, success, empty, and failure state" do
+    let
+      loading = startWalletDiscovery defaultState
+      loaded = finishWalletDiscovery [ lace ] loading
+      empty = finishWalletDiscovery [] loading
+      failed = failWalletDiscovery "wallet discovery failed" loading
+
+    loading.walletSession.wallets `shouldEqual` Loading
+    loaded.walletSession.wallets `shouldEqual` Success [ lace ]
+    loaded.walletSession.feedback `shouldEqual` Nothing
+    empty.walletSession.wallets `shouldEqual` Success []
+    empty.walletSession.feedback `shouldEqual` Just "No CIP-30 wallet found."
+    failed.walletSession.wallets `shouldEqual` Failure "wallet discovery failed"
+    failed.walletSession.feedback `shouldEqual` Just "wallet discovery failed"
+
+  it "records the selected wallet while connection is in progress" do
+    let
+      state = startWalletConnection lace defaultState
+
+    state.walletSession.status `shouldEqual` WalletConnecting
+    state.walletSession.walletKey `shouldEqual` Just "lace"
+    state.walletSession.walletName `shouldEqual` Just "Lace"
+    state.walletSession.selectedAddress `shouldEqual` Nothing
+    state.walletSession.feedback `shouldEqual` Nothing
+
+  it "stores successful wallet details with used-address priority" do
+    let
+      state = finishWalletConnection lace connectedDetails defaultState
+
+    state.walletSession.status `shouldEqual` WalletConnected
+    state.walletSession.walletKey `shouldEqual` Just "lace"
+    state.walletSession.walletName `shouldEqual` Just "Lace"
+    state.walletSession.networkId `shouldEqual` Just 0
+    state.walletSession.network `shouldEqual` Just "preprod/testnet"
+    state.walletSession.selectedAddress `shouldEqual` Just "addr_used"
+    state.walletSession.changeAddress `shouldEqual` Just "addr_change"
+    state.walletSession.usedAddresses `shouldEqual` [ "addr_used", "addr_second" ]
+    state.walletSession.lovelace `shouldEqual` Just "1234567"
+    state.walletSession.feedback `shouldEqual` Just "Connected to Lace."
+
+  it "falls back to change address when there are no used addresses" do
+    let
+      state =
+        finishWalletConnection lace
+          (connectedDetails { usedAddresses = [] })
+          defaultState
+
+    state.walletSession.selectedAddress `shouldEqual` Just "addr_change"
+    state.walletSession.usedAddresses `shouldEqual` []
+
+  it "accepts preprod/testnet and rejects unsupported network ids" do
+    let
+      preprod = finishWalletConnection lace connectedDetails defaultState
+      mainnet =
+        finishWalletConnection lace
+          (connectedDetails { networkId = 1 })
+          defaultState
+      unknown =
+        finishWalletConnection lace
+          (connectedDetails { networkId = 42 })
+          defaultState
+
+    preprod.walletSession.status `shouldEqual` WalletConnected
+    preprod.walletSession.network `shouldEqual` Just "preprod/testnet"
+    mainnet.walletSession.status `shouldEqual` WalletDisconnected
+    mainnet.walletSession.feedback
+      `shouldEqual`
+        Just "Switch the wallet to preprod before connecting."
+    unknown.walletSession.status `shouldEqual` WalletDisconnected
+    unknown.walletSession.feedback
+      `shouldEqual`
+        Just "Switch the wallet to preprod before connecting."
+
+  it "disconnects the wallet without changing unrelated app state" do
+    let
+      selected = TokenId "token"
+      connected =
+        finishWalletConnection lace connectedDetails
+          (defaultState { selectedToken = Just selected })
+      disconnected = disconnectWallet connected
+
+    disconnected.selectedToken `shouldEqual` Just selected
+    disconnected.walletSession.status `shouldEqual` WalletDisconnected
+    disconnected.walletSession.walletKey `shouldEqual` Nothing
+    disconnected.walletSession.walletName `shouldEqual` Nothing
+    disconnected.walletSession.selectedAddress `shouldEqual` Nothing
+    disconnected.walletSession.feedback `shouldEqual` Just "Wallet disconnected."
+
+lace :: WalletInfo
+lace = { key: "lace", name: "Lace", icon: "" }
+
+connectedDetails :: ConnectedWalletDetails
+connectedDetails =
+  { networkId: 0
+  , usedAddresses: [ "addr_used", "addr_second" ]
+  , changeAddress: "addr_change"
+  , lovelace: Just "1234567"
+  }

--- a/test/Test/AppWriteSpec.purs
+++ b/test/Test/AppWriteSpec.purs
@@ -1,0 +1,121 @@
+module Test.AppWriteSpec (spec) where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import MPFS.Client (decodeRequestsBody)
+import MPFS.App.State (WalletStatus(..), defaultState)
+import MPFS.App.Write
+  ( RefreshTarget(..)
+  , WriteOperation(..)
+  , WriteStatus(..)
+  , failWrite
+  , initialWriteForms
+  , refreshPlanAfterSubmit
+  , requestIdOf
+  , submittedWrite
+  , validatePrerequisites
+  )
+import MPFS.Client.Types (PendingRequest)
+import MPFS.Types (RequestId(..), TokenId(..), UnsignedTxCbor(..))
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (fail, shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS App Write" do
+  it "tracks write operation status through successful submit details" do
+    let
+      submitted =
+        submittedWrite
+          (UnsignedTxCbor "unsigned-cbor")
+          "witness-cbor"
+          "signed-cbor"
+          "tx-id"
+
+    submitted
+      `shouldEqual`
+        WriteSubmitted
+          (UnsignedTxCbor "unsigned-cbor")
+          "witness-cbor"
+          "signed-cbor"
+          "tx-id"
+
+  it "fails selected-token writes before any build action when prerequisites are missing" do
+    validatePrerequisites WriteInsertFact defaultState
+      `shouldEqual`
+        Left "Connect a wallet first."
+
+    validatePrerequisites WriteInsertFact
+      ( defaultState
+          { walletSession =
+              defaultState.walletSession
+                { status = WalletConnected
+                , selectedAddress = Just "addr_test1"
+                }
+          }
+      )
+      `shouldEqual`
+        Left "Select a token first."
+
+  it "does not require a selected token to register a new token" do
+    validatePrerequisites WriteRegisterToken
+      ( defaultState
+          { walletSession =
+              defaultState.walletSession
+                { status = WalletConnected
+                , selectedAddress = Just "addr_test1"
+                }
+          }
+      )
+      `shouldEqual`
+        Right unit
+
+  it "records failed writes in app state without changing form input" do
+    let
+      state = defaultState { writeForms = initialWriteForms { insertKey = "name" } }
+      failed = failWrite "build failed" state
+
+    failed.writeStatus `shouldEqual` WriteFailed "build failed"
+    failed.writeForms.insertKey `shouldEqual` "name"
+
+  it "plans read refreshes after a submitted selected-token write" do
+    refreshPlanAfterSubmit (Just (TokenId "token-1"))
+      `shouldEqual`
+        [ RefreshTokens
+        , RefreshTokenFacts (TokenId "token-1")
+        , RefreshTokenState (TokenId "token-1")
+        , RefreshPendingRequests (TokenId "token-1")
+        ]
+
+  it "derives request ids from pending request rows" do
+    requestIdOf pendingRequest
+      `shouldEqual`
+        Just (RequestId "aaaaaaaa#2")
+
+  it "decodes request ids from witnessed pending request UTxO refs" do
+    case decodeRequestsBody requestResponseBody of
+      Left err ->
+        fail (show err)
+      Right requests ->
+        map requestIdOf requests
+          `shouldEqual`
+            [ Just (RequestId "bbbbbbbb#3") ]
+
+pendingRequest :: PendingRequest
+pendingRequest =
+  { token: "token-1"
+  , owner: "owner"
+  , key: "6b6579"
+  , operation: "insert"
+  , value: Just "76616c7565"
+  , fee: 0.0
+  , submitted_at: 100.0
+  , request_id: "aaaaaaaa#2"
+  }
+
+requestResponseBody :: String
+requestResponseBody =
+  """
+  {"requests":[{"token":"token-1","owner":"owner","key":"6b6579","operation":"insert","value":"76616c7565","fee":0,"submitted_at":100,"utxo":{"tx_in":{"tx_id":"bbbbbbbb","tx_ix":3},"tx_out":"00"}}]}
+  """

--- a/test/Test/FactsSpec.purs
+++ b/test/Test/FactsSpec.purs
@@ -128,6 +128,7 @@ pendingAt submittedAt =
   , value: Just "76616c7565"
   , fee: 0.0
   , submitted_at: submittedAt
+  , request_id: "aaaaaaaa#2"
   }
 
 facts :: Array FactEntry

--- a/test/Test/FactsSpec.purs
+++ b/test/Test/FactsSpec.purs
@@ -1,0 +1,136 @@
+module Test.FactsSpec (spec) where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import MPFS.App.Facts
+  ( RequestPhase(..)
+  , failFactLookup
+  , finishFactLookup
+  , finishFactsLoad
+  , finishFactsLoadAt
+  , phaseLabel
+  , requestPhase
+  , startFactLookup
+  , startFactsLoad
+  )
+import MPFS.App.State (defaultState)
+import MPFS.App.Verification
+  ( VerificationStatus(..)
+  , finishVerification
+  , startVerification
+  )
+import MPFS.Client.Types (FactEntry, PendingRequest, TokenState)
+import MPFS.Types (TokenId(..))
+import MPFS.UI.Remote (Remote(..))
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS App Facts" do
+  it "marks facts, token state, and pending requests as loading" do
+    let
+      selected = TokenId "token"
+
+      state =
+        defaultState
+          { selectedToken = Just selected
+          , facts = Success facts
+          , tokenState = Success tokenState
+          , pendingRequests = Success [ pendingAt 0.0 ]
+          }
+
+      next = startFactsLoad state
+
+    next.facts `shouldEqual` Loading
+    next.tokenState `shouldEqual` Loading
+    next.pendingRequests `shouldEqual` Loading
+    next.selectedToken `shouldEqual` Just selected
+
+  it "stores loaded token state, pending requests, and facts" do
+    let
+      selected = TokenId "token"
+      request = pendingAt 100.0
+      requestNowMillis = 1234.0
+
+      state = defaultState { selectedToken = Just selected }
+
+      next = finishFactsLoadAt requestNowMillis tokenState [ request ] facts state
+
+    next.tokenState `shouldEqual` Success tokenState
+    next.pendingRequests `shouldEqual` Success [ request ]
+    next.facts `shouldEqual` Success facts
+    next.requestNowMillis `shouldEqual` requestNowMillis
+    next.selectedToken `shouldEqual` Just selected
+
+  it "defaults loaded request time for compatibility" do
+    let
+      next = finishFactsLoad tokenState [] facts defaultState
+
+    next.requestNowMillis `shouldEqual` 0.0
+
+  it "classifies pending request phase from token timing windows" do
+    requestPhase 110.0 tokenState (pendingAt 100.0)
+      `shouldEqual`
+        PhaseProcessable
+    requestPhase 111.0 tokenState (pendingAt 100.0)
+      `shouldEqual`
+        PhaseRetractable
+    requestPhase 130.0 tokenState (pendingAt 100.0)
+      `shouldEqual`
+        PhaseRetractable
+    requestPhase 131.0 tokenState (pendingAt 100.0)
+      `shouldEqual`
+        PhaseExpired
+    phaseLabel PhaseExpired `shouldEqual` "expired"
+
+  it "tracks fact lookup loading, success, and failure" do
+    let
+      loading = startFactLookup "6b6579" defaultState
+      lookedUp = finishFactLookup "76616c7565" loading
+      failed = failFactLookup "not found" loading
+
+    loading.factLookup.key `shouldEqual` "6b6579"
+    loading.factLookup.value `shouldEqual` Loading
+    loading.factLookup.verification `shouldEqual` VerificationNotAsked
+    lookedUp.factLookup.value `shouldEqual` Success "76616c7565"
+    lookedUp.factLookup.verification `shouldEqual` VerificationNotAsked
+    failed.factLookup.value `shouldEqual` Failure "not found"
+
+  it "tracks verification loading and reactor verdicts" do
+    let
+      loading = startVerification defaultState
+      verified = finishVerification (Right unit) loading
+      failed = finishVerification (Left "root mismatch") loading
+
+    loading.factLookup.verification `shouldEqual` VerificationLoading
+    verified.factLookup.verification `shouldEqual` VerificationVerified
+    failed.factLookup.verification
+      `shouldEqual`
+        VerificationFailed "root mismatch"
+
+tokenState :: TokenState
+tokenState =
+  { owner: "owner"
+  , root: "root"
+  , max_fee: 2.0
+  , process_time: 10.0
+  , retract_time: 20.0
+  }
+
+pendingAt :: Number -> PendingRequest
+pendingAt submittedAt =
+  { token: "token"
+  , owner: "owner"
+  , key: "6b6579"
+  , operation: "insert"
+  , value: Just "76616c7565"
+  , fee: 0.0
+  , submitted_at: submittedAt
+  }
+
+facts :: Array FactEntry
+facts =
+  [ { key: "6b6579", value: "76616c7565" }
+  ]

--- a/test/Test/MPFS/CageSpec.purs
+++ b/test/Test/MPFS/CageSpec.purs
@@ -1,0 +1,134 @@
+-- | Tests for cage reactor output parsing and write-envelope construction.
+module Test.MPFS.CageSpec (spec) where
+
+import Prelude
+
+import Data.Argonaut.Core (Json, fromObject, fromString)
+import Data.Argonaut.Decode (decodeJson)
+import Data.Argonaut.Decode.Error (JsonDecodeError)
+import Data.Argonaut.Parser (jsonParser)
+import Data.Bifunctor (lmap)
+import Data.Either (Either(..))
+import Data.Maybe (maybe)
+import Data.Tuple (Tuple(..))
+import Foreign.Object as Object
+import MPFS.Cage.Reactor
+  ( parseCageTxOutput
+  , parseDecodedOutput
+  , parseSignedTxOutput
+  )
+import MPFS.Cage.Wasm
+  ( buildAssembleEnvelope
+  , buildBootEnvelope
+  , buildRequestEnvelope
+  )
+import MPFS.Types (CageConfig, CageError, TrustedRoot(..), cageErrorMessage)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (fail, shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS Cage Boundary" do
+  it "parses cage and signed transaction reactor output" do
+    parseCageTxOutput okCageTx `shouldEqual` Right "deadbeef"
+    parseSignedTxOutput okSignedTx `shouldEqual` Right "cafebabe"
+    parseErrorMessage (parseCageTxOutput badOutput)
+      `shouldEqual`
+        Left "decoded: {}"
+
+  it "parses decoded reactor JSON output" do
+    case parseDecodedOutput okDecoded of
+      Left err -> fail (cageErrorMessage err)
+      Right json ->
+        jsonStringField "token_id" json `shouldEqual` Right "token-1"
+
+  it "builds boot and request envelopes with required cage fields" do
+    let
+      boot = buildBootEnvelope trustedRoot evalContext cageConfig facts
+      request =
+        buildRequestEnvelope
+          "request_insert"
+          trustedRoot
+          evalContext
+          cageConfig
+          facts
+    envelopeStringField "op" boot `shouldEqual` Right "boot"
+    envelopeStringField "trusted_root" boot `shouldEqual` Right "root-1"
+    envelopeStringField "op" request `shouldEqual` Right "request_insert"
+    envelopeNestedStringField "cage_config" "network" request
+      `shouldEqual`
+        Right "preprod"
+
+  it "builds assemble envelopes with unsigned tx and witness set" do
+    let
+      envelope = buildAssembleEnvelope "unsigned-cbor" "witness-cbor"
+    envelopeStringField "op" envelope `shouldEqual` Right "assemble"
+    envelopeStringField "unsigned_tx" envelope
+      `shouldEqual`
+        Right "unsigned-cbor"
+    envelopeStringField "witness_set" envelope
+      `shouldEqual`
+        Right "witness-cbor"
+
+okCageTx :: { stdout :: String, stderr :: String, exitOk :: Boolean }
+okCageTx = { stdout: "cage_tx: deadbeef\nignored", stderr: "", exitOk: true }
+
+okSignedTx :: { stdout :: String, stderr :: String, exitOk :: Boolean }
+okSignedTx = { stdout: "signed_tx: cafebabe", stderr: "", exitOk: true }
+
+okDecoded :: { stdout :: String, stderr :: String, exitOk :: Boolean }
+okDecoded =
+  { stdout: "decoded: {\"token_id\":\"token-1\"}"
+  , stderr: ""
+  , exitOk: true
+  }
+
+badOutput :: { stdout :: String, stderr :: String, exitOk :: Boolean }
+badOutput = { stdout: "decoded: {}", stderr: "", exitOk: true }
+
+trustedRoot :: TrustedRoot
+trustedRoot = TrustedRoot "root-1"
+
+cageConfig :: CageConfig
+cageConfig =
+  { cageScriptBytes: "cage-script"
+  , requestScriptBytes: "request-script"
+  , cfgScriptHash: "script-hash"
+  , defaultProcessTime: 10
+  , defaultRetractTime: 20
+  , defaultTip: 30
+  , network: "preprod"
+  }
+
+evalContext :: Json
+evalContext = jsonObject [ Tuple "era" (fromString "conway") ]
+
+facts :: Json
+facts = jsonObject [ Tuple "wallet" (fromString "addr_test1") ]
+
+jsonObject :: Array (Tuple String Json) -> Json
+jsonObject = fromObject <<< Object.fromFoldable
+
+parseErrorMessage :: forall a. Either CageError a -> Either String a
+parseErrorMessage = lmap cageErrorMessage
+
+envelopeStringField :: String -> String -> Either String String
+envelopeStringField field body = do
+  json <- lmap show (jsonParser body)
+  jsonStringField field json
+
+envelopeNestedStringField :: String -> String -> String -> Either String String
+envelopeNestedStringField outer inner body = do
+  json <- lmap show (jsonParser body)
+  object <- jsonObjectFields json
+  nested <- maybe (Left ("missing field " <> outer)) Right (Object.lookup outer object)
+  jsonStringField inner nested
+
+jsonStringField :: String -> Json -> Either String String
+jsonStringField field json = do
+  object <- jsonObjectFields json
+  value <- maybe (Left ("missing field " <> field)) Right (Object.lookup field object)
+  lmap show (decodeJson value :: Either JsonDecodeError String)
+
+jsonObjectFields :: Json -> Either String (Object.Object Json)
+jsonObjectFields json =
+  lmap show (decodeJson json :: Either JsonDecodeError (Object.Object Json))

--- a/test/Test/MPFS/ClientSpec.purs
+++ b/test/Test/MPFS/ClientSpec.purs
@@ -12,12 +12,29 @@ import Effect.Exception (error)
 import Node.Process (lookupEnv)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual, fail)
-import MPFS.Client (decodeTokensBody, mkClient)
+import MPFS.Client
+  ( decodeFactBody
+  , decodeFactsBody
+  , decodeTokensBody
+  , mkClient
+  )
 
 bumpedTokensResponseBody :: String
 bumpedTokensResponseBody =
   """
   {"snapshot":{"chainpoint":{"slot":42,"block_id":"1111111111111111111111111111111111111111111111111111111111111111"},"utxo_root":"2222222222222222222222222222222222222222222222222222222222222222"},"tokens":{"entries":[],"completeness_proof":"00"}}
+  """
+
+factsResponseBody :: String
+factsResponseBody =
+  """
+  {"snapshot":{"chainpoint":{"slot":42,"block_id":"1111111111111111111111111111111111111111111111111111111111111111"},"utxo_root":"2222222222222222222222222222222222222222222222222222222222222222"},"state":{},"facts":[{"key":"6b6579","value":"76616c7565"}]}
+  """
+
+factResponseBody :: String
+factResponseBody =
+  """
+  {"snapshot":{"chainpoint":{"slot":42,"block_id":"1111111111111111111111111111111111111111111111111111111111111111"},"utxo_root":"2222222222222222222222222222222222222222222222222222222222222222"},"value":"76616c7565","fact":{}}
   """
 
 baseUrl :: Aff String
@@ -36,6 +53,18 @@ spec = describe "MPFS Client E2E" do
       Left err -> fail $ show err
       Right tokens ->
         tokens `shouldEqual` []
+
+  it "decodes GET /tokens/:id/facts response entries" do
+    case decodeFactsBody factsResponseBody of
+      Left err -> fail $ show err
+      Right facts ->
+        facts `shouldEqual` [ { key: "6b6579", value: "76616c7565" } ]
+
+  it "decodes GET /tokens/:id/facts/:key response value" do
+    case decodeFactBody factResponseBody of
+      Left err -> fail $ show err
+      Right value ->
+        value `shouldEqual` "76616c7565"
 
   it "GET /status returns tip slot" do
     url <- baseUrl

--- a/test/Test/MPFS/WalletSpec.purs
+++ b/test/Test/MPFS/WalletSpec.purs
@@ -1,0 +1,39 @@
+-- | Tests for pure wallet display helpers.
+module Test.MPFS.WalletSpec (spec) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import MPFS.Wallet.Cip30
+  ( lovelaceOfBalance
+  , networkName
+  , ownerKeyHashOfAddress
+  )
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS Wallet CIP-30 Helpers" do
+  it "labels known and unknown CIP-30 networks" do
+    networkName 1 `shouldEqual` "mainnet"
+    networkName 0 `shouldEqual` "testnet"
+    networkName 42 `shouldEqual` "network 42"
+
+  it "extracts payment key hashes from Shelley key-payment addresses" do
+    ownerKeyHashOfAddress keyPaymentAddress `shouldEqual` Just paymentKeyHash
+    ownerKeyHashOfAddress scriptPaymentAddress `shouldEqual` Nothing
+    ownerKeyHashOfAddress "not hex" `shouldEqual` Nothing
+
+  it "extracts lovelace from display-only balance CBOR" do
+    lovelaceOfBalance "1903e8" `shouldEqual` Just "1000"
+    lovelaceOfBalance "821903e8a0" `shouldEqual` Just "1000"
+    lovelaceOfBalance "a0" `shouldEqual` Nothing
+
+paymentKeyHash :: String
+paymentKeyHash = "00112233445566778899aabbccddeeff00112233445566778899aabb"
+
+keyPaymentAddress :: String
+keyPaymentAddress = "00" <> paymentKeyHash <> "ff"
+
+scriptPaymentAddress :: String
+scriptPaymentAddress = "10" <> paymentKeyHash <> "ff"

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -4,14 +4,15 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Effect.Class (liftEffect)
 import Node.Process (lookupEnv)
 import Test.Spec (Spec)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner.Node (runSpecAndExitProcess)
+import Test.MPFS.CageSpec as CageSpec
 import Test.MPFS.ClientSpec as ClientSpec
 import Test.MPFS.ProofSpec as ProofSpec
 import Test.MPFS.TxCborSpec as TxCborSpec
+import Test.MPFS.WalletSpec as WalletSpec
 
 main :: Effect Unit
 main = do
@@ -19,8 +20,10 @@ main = do
   let
     specs :: Spec Unit
     specs = do
+      CageSpec.spec
       ProofSpec.spec
       TxCborSpec.spec
+      WalletSpec.spec
       case mUrl of
         Nothing -> pure unit
         Just _ -> ClientSpec.spec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,6 +8,7 @@ import Node.Process (lookupEnv)
 import Test.Spec (Spec)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner.Node (runSpecAndExitProcess)
+import Test.AppWalletSpec as AppWalletSpec
 import Test.AppSpec as AppSpec
 import Test.FactsSpec as FactsSpec
 import Test.MPFS.CageSpec as CageSpec
@@ -24,6 +25,7 @@ main = do
     specs :: Spec Unit
     specs = do
       AppSpec.spec
+      AppWalletSpec.spec
       CageSpec.spec
       FactsSpec.spec
       ProofSpec.spec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -9,6 +9,7 @@ import Test.Spec (Spec)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner.Node (runSpecAndExitProcess)
 import Test.AppSpec as AppSpec
+import Test.FactsSpec as FactsSpec
 import Test.MPFS.CageSpec as CageSpec
 import Test.MPFS.ClientSpec as ClientSpec
 import Test.MPFS.ProofSpec as ProofSpec
@@ -24,6 +25,7 @@ main = do
     specs = do
       AppSpec.spec
       CageSpec.spec
+      FactsSpec.spec
       ProofSpec.spec
       TokensSpec.spec
       TxCborSpec.spec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -10,6 +10,7 @@ import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner.Node (runSpecAndExitProcess)
 import Test.AppWalletSpec as AppWalletSpec
 import Test.AppSpec as AppSpec
+import Test.AppWriteSpec as AppWriteSpec
 import Test.FactsSpec as FactsSpec
 import Test.MPFS.CageSpec as CageSpec
 import Test.MPFS.ClientSpec as ClientSpec
@@ -26,6 +27,7 @@ main = do
     specs = do
       AppSpec.spec
       AppWalletSpec.spec
+      AppWriteSpec.spec
       CageSpec.spec
       FactsSpec.spec
       ProofSpec.spec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,6 +8,7 @@ import Node.Process (lookupEnv)
 import Test.Spec (Spec)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner.Node (runSpecAndExitProcess)
+import Test.AppSpec as AppSpec
 import Test.MPFS.CageSpec as CageSpec
 import Test.MPFS.ClientSpec as ClientSpec
 import Test.MPFS.ProofSpec as ProofSpec
@@ -20,6 +21,7 @@ main = do
   let
     specs :: Spec Unit
     specs = do
+      AppSpec.spec
       CageSpec.spec
       ProofSpec.spec
       TxCborSpec.spec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -14,6 +14,7 @@ import Test.MPFS.ClientSpec as ClientSpec
 import Test.MPFS.ProofSpec as ProofSpec
 import Test.MPFS.TxCborSpec as TxCborSpec
 import Test.MPFS.WalletSpec as WalletSpec
+import Test.TokensSpec as TokensSpec
 
 main :: Effect Unit
 main = do
@@ -24,6 +25,7 @@ main = do
       AppSpec.spec
       CageSpec.spec
       ProofSpec.spec
+      TokensSpec.spec
       TxCborSpec.spec
       WalletSpec.spec
       case mUrl of

--- a/test/Test/TokensSpec.purs
+++ b/test/Test/TokensSpec.purs
@@ -1,0 +1,65 @@
+module Test.TokensSpec (spec) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import MPFS.App.State (defaultState)
+import MPFS.App.Tokens
+  ( failTokenLoad
+  , finishTokenLoad
+  , selectToken
+  , startTokenLoad
+  )
+import MPFS.Types (TokenId(..))
+import MPFS.UI.Remote (Remote(..))
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS App Tokens" do
+  it "marks tokens as loading without changing the selected token" do
+    let
+      selected = TokenId "existing"
+      state = defaultState { selectedToken = Just selected }
+      next = startTokenLoad state
+
+    next.tokens `shouldEqual` Loading
+    next.selectedToken `shouldEqual` Just selected
+
+  it "stores loaded tokens and selects the first token when none is selected" do
+    let
+      alpha = TokenId "alpha"
+      beta = TokenId "beta"
+      next = finishTokenLoad [ alpha, beta ] defaultState
+
+    next.tokens `shouldEqual` Success [ alpha, beta ]
+    next.selectedToken `shouldEqual` Just alpha
+
+  it "preserves an existing selected token when it is still present" do
+    let
+      alpha = TokenId "alpha"
+      beta = TokenId "beta"
+      state = defaultState { selectedToken = Just beta }
+      next = finishTokenLoad [ alpha, beta ] state
+
+    next.tokens `shouldEqual` Success [ alpha, beta ]
+    next.selectedToken `shouldEqual` Just beta
+
+  it "selects a token without changing the loaded token list" do
+    let
+      alpha = TokenId "alpha"
+      beta = TokenId "beta"
+      state = defaultState { tokens = Success [ alpha, beta ] }
+      next = selectToken beta state
+
+    next.tokens `shouldEqual` Success [ alpha, beta ]
+    next.selectedToken `shouldEqual` Just beta
+
+  it "stores a load failure without clearing the selected token" do
+    let
+      selected = TokenId "existing"
+      state = defaultState { selectedToken = Just selected }
+      next = failTokenLoad "network unavailable" state
+
+    next.tokens `shouldEqual` Failure "network unavailable"
+    next.selectedToken `shouldEqual` Just selected


### PR DESCRIPTION
## Summary

Ports the mature `mpfs-spa` client into `cardano-mpfs-browser` as a Halogen browser workbench while preserving the WASM-Haskell reactor boundaries.

Parent: #34
Closes #32

## Slices

- S1: Logic libraries and cage reactor boundary
- S2: Halogen app shell and tab routing
- S3: Tokens tab read path
- S4: Facts tab read and verification path
- S5: Connect tab and wallet state
- S6: Write flow and End tab
- Final: task metadata and final gate

## Verification

- `./gate.sh` passed on each accepted slice commit.
- Final `./gate.sh` passed at HEAD with lint, build, bundle, unit tests, and e2e.
- Final test count: 58/58 tests passed.