### PR TITLE
Deployable dev.plutimus preview: runtime API base + static-preview CI

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,51 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.event.action != 'closed'
+    runs-on: nixos
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build SPA bundle
+        run: nix develop --quiet --command bash -c 'npm ci && just bundle'
+
+      - name: Point preview at live UMPFS
+        run: printf 'window.MPFS_BASE_URL = "https://umpfs.plutimus.com";\n' > dist/config.js
+
+      - name: Verify cage config
+        run: nix develop --quiet --command just verify-cage-config
+
+      - name: Publish PR preview
+        uses: paolino/dev-assets/static-preview@main
+        with:
+          path: dist
+          comment-marker: "<!-- mpfs-spa-preview-url -->"
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: nixos
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: paolino/dev-assets/static-preview@main
+        with:
+          mode: cleanup
+          comment-marker: "<!-- mpfs-spa-preview-url -->"

--- a/WIP.md
+++ b/WIP.md
@@ -1,0 +1,3 @@
+# WIP
+
+- T60-S1: renamed runtime browser global to `window.MPFS_BASE_URL` so the cage-config verifier's `__MPFS_*__` placeholder scan remains reserved for cage substitutions.

--- a/WIP.md
+++ b/WIP.md
@@ -1,3 +1,7 @@
 # WIP
 
 - T60-S1: renamed runtime browser global to `window.MPFS_BASE_URL` so the cage-config verifier's `__MPFS_*__` placeholder scan remains reserved for cage substitutions.
+- T60-S2: RED intentionally skipped because this slice is CI YAML and has no unit harness; local proof is YAML parsing plus the unchanged project gate, while live preview publication is checked post-push.
+- T60-S2: `.github/workflows/preview.yml` parses locally with `yq '.' .github/workflows/preview.yml`.
+- T60-S2: `nix develop -c ./gate.sh` passed locally, including bundle, cage config verification, and 121/121 tests.
+- T60-S2: preview CI build step now runs `npm ci && just bundle` inside `nix develop` so fresh checkouts install `@bjorn3/browser_wasi_shim` before esbuild.

--- a/dist/config.js
+++ b/dist/config.js
@@ -1,0 +1,1 @@
+window.MPFS_BASE_URL = "/api";

--- a/dist/index.html
+++ b/dist/index.html
@@ -22,9 +22,9 @@
             background: var(--bg);
             color: var(--fg);
             line-height: 1.5;
+            min-height: 100vh;
         }
         button { font: inherit; }
-        #app { min-height: 100vh; }
         .app-shell {
             width: min(1120px, calc(100vw - 32px));
             margin: 0 auto;
@@ -32,7 +32,7 @@
         }
         .shell-header {
             display: flex;
-            align-items: flex-end;
+            align-items: center;
             justify-content: space-between;
             gap: 24px;
             padding-bottom: 18px;
@@ -63,6 +63,7 @@
             background: var(--surface);
             padding: 8px 10px;
             border-radius: 6px;
+            box-shadow: 0 1px 2px rgba(31, 41, 51, 0.05);
         }
         .status-pill span,
         .field-line span {
@@ -124,6 +125,7 @@
             border-radius: 8px;
             min-height: 360px;
             padding: 22px;
+            box-shadow: 0 2px 10px rgba(31, 41, 51, 0.05);
         }
         .panel-layout {
             display: grid;
@@ -192,7 +194,6 @@
     </style>
 </head>
 <body>
-    <div id="app"></div>
     <script src="config.js"></script>
     <script src="index.js"></script>
 </body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -193,6 +193,7 @@
 </head>
 <body>
     <div id="app"></div>
+    <script src="config.js"></script>
     <script src="index.js"></script>
 </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -168,6 +168,73 @@
             padding: 0 14px;
             cursor: not-allowed;
         }
+        .primary-button {
+            min-height: 40px;
+            border: 1px solid var(--accent);
+            border-radius: 6px;
+            background: var(--accent);
+            color: #fff;
+            padding: 0 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.15s ease, border-color 0.15s ease;
+        }
+        .primary-button:hover:not(:disabled) {
+            background: #0b5d56;
+            border-color: #0b5d56;
+        }
+        .primary-button:disabled {
+            background: var(--surface-2);
+            border-color: var(--border);
+            color: var(--disabled);
+            cursor: not-allowed;
+        }
+        .token-list {
+            grid-column: 1 / -1;
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-top: 4px;
+        }
+        .token-list li {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        .token-list li strong {
+            overflow-wrap: anywhere;
+            font-weight: 600;
+        }
+        .token-row {
+            flex: 1 1 auto;
+            text-align: left;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--surface);
+            padding: 10px 12px;
+            cursor: pointer;
+            overflow-wrap: anywhere;
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 0.82rem;
+            transition: border-color 0.15s ease, background 0.15s ease;
+        }
+        .token-row:hover { border-color: var(--accent); }
+        .token-row.is-selected {
+            border-color: var(--accent);
+            background: #e0f2ef;
+            color: #063f3b;
+        }
+        .empty-state,
+        .loading-state,
+        .error-state {
+            grid-column: 1 / -1;
+            color: var(--muted);
+            padding: 4px 0;
+        }
+        .error-state { color: var(--accent-2); }
         @media (max-width: 720px) {
             .app-shell {
                 width: min(100vw - 20px, 1120px);

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# dev.plutimus preview ticket #60 gate
+just lint
+just build
+just bundle
+just verify-cage-config
+just test

--- a/specs/60-dev-preview/plan.md
+++ b/specs/60-dev-preview/plan.md
@@ -1,0 +1,42 @@
+# Plan — #60 Deployable dev.plutimus preview
+
+## Outcome
+A PR preview at `preview.dev.plutimus.com/lambdasistemi/cardano-mpfs-browser/pr-<N>/`
+runs the real SPA against live `umpfs.plutimus.com` (CORS-enabled in offchain#384)
+with no local proxy. SecondOracle already absolute + CORS `*`, untouched.
+
+## Design
+
+### Runtime API base (replaces hardcoded `/api`)
+- The base is provided at startup, not compiled in. Default stays `/api` so the
+  local same-origin proxy dev flow is unchanged.
+- Pure, testable core: `resolveBaseUrl :: Maybe String -> String`
+  (`Nothing -> "/api"`, `Just s -> s`).
+- Thin FFI: `readApiBaseUrl :: Effect (Maybe String)` reads
+  `window.MPFS_BASE_URL` (empty/undefined -> `Nothing`). NOTE: the global is
+  deliberately NOT `__MPFS_..__`-wrapped — the cage-config bundle verifier scans
+  `/__MPFS_[A-Z0-9_]+__/g` and would flag a wrapped token as an un-substituted
+  placeholder.
+- Wiring: `Main.purs` reads the base once and passes it as the component Input;
+  `App.component` Input becomes `{ baseUrl :: String }`;
+  `initialState input = defaultState { baseUrl = input.baseUrl }`.
+- Config file: committed `dist/config.js` sets the default
+  `window.MPFS_BASE_URL = "/api";`; `dist/index.html` loads it *before*
+  `index.js`. `dist/config.js` is tracked (only `dist/index.js` + `dist/*.wasm`
+  are gitignored).
+
+### Preview publish
+- `.github/workflows/preview.yml` on `pull_request`:
+  build (`just bundle` + `just verify-cage-config`), overwrite `dist/config.js`
+  with `window.__MPFS_BASE_URL__ = "https://umpfs.plutimus.com";`, then
+  `paolino/dev-assets/static-preview@main` publishes `dist/` to
+  `preview.dev.plutimus.com/lambdasistemi/cardano-mpfs-browser/pr-<N>/` and
+  comments the URL.
+
+## Slices (bisect-safe)
+- **Slice 1 — runtime API base.** App code + config file + unit test. After it,
+  local default is still `/api`; the base is now injectable. Owned: new
+  `RuntimeConfig` module (+ `.js`), `Main.purs`, `App.purs` (Input type +
+  initialState), `dist/index.html`, `dist/config.js`, a `test/Test/**` spec.
+- **Slice 2 — preview CI.** `.github/workflows/preview.yml` only. Infra; no unit
+  harness for CI YAML (documented exception) — proof is the live preview URL.

--- a/specs/60-dev-preview/tasks.md
+++ b/specs/60-dev-preview/tasks.md
@@ -3,12 +3,12 @@
 ## Slice 1 — runtime API base
 - [X] T60-S1 `resolveBaseUrl :: Maybe String -> String` (pure) with a RED unit
       test (`Nothing -> "/api"`, `Just "x" -> "x"`), a `readApiBaseUrl` FFI
-      reading `window.__MPFS_BASE_URL__`, `Main.purs` + `App.component` Input
+      reading `window.MPFS_BASE_URL`, `Main.purs` + `App.component` Input
       wiring (`initialState` sets `baseUrl` from input), committed
       `dist/config.js` (default `/api`) loaded by `dist/index.html` before
       `index.js`. Gate green (`./gate.sh`). One commit.
 
 ## Slice 2 — preview CI
-- [ ] T60-S2 `.github/workflows/preview.yml` (on `pull_request`): build the SPA,
+- [X] T60-S2 `.github/workflows/preview.yml` (on `pull_request`): build the SPA,
       overwrite `dist/config.js` -> `https://umpfs.plutimus.com`, publish `dist/`
       via `paolino/dev-assets/static-preview@main`, comment the URL. One commit.

--- a/specs/60-dev-preview/tasks.md
+++ b/specs/60-dev-preview/tasks.md
@@ -1,0 +1,14 @@
+# Tasks — #60
+
+## Slice 1 — runtime API base
+- [X] T60-S1 `resolveBaseUrl :: Maybe String -> String` (pure) with a RED unit
+      test (`Nothing -> "/api"`, `Just "x" -> "x"`), a `readApiBaseUrl` FFI
+      reading `window.__MPFS_BASE_URL__`, `Main.purs` + `App.component` Input
+      wiring (`initialState` sets `baseUrl` from input), committed
+      `dist/config.js` (default `/api`) loaded by `dist/index.html` before
+      `index.js`. Gate green (`./gate.sh`). One commit.
+
+## Slice 2 — preview CI
+- [ ] T60-S2 `.github/workflows/preview.yml` (on `pull_request`): build the SPA,
+      overwrite `dist/config.js` -> `https://umpfs.plutimus.com`, publish `dist/`
+      via `paolino/dev-assets/static-preview@main`, comment the URL. One commit.

--- a/src/App.purs
+++ b/src/App.purs
@@ -77,10 +77,14 @@ data Action
   | UpdateFactProofEnvelope String
   | VerifyFactEnvelope
 
-component :: forall q i o m. MonadAff m => H.Component q i o m
+type Input =
+  { baseUrl :: String
+  }
+
+component :: forall q o m. MonadAff m => H.Component q Input o m
 component =
   H.mkComponent
-    { initialState: const defaultState
+    { initialState
     , render:
         View.render
           { selectTab: SelectTab
@@ -118,6 +122,9 @@ component =
           , handleAction = handleAction
           }
     }
+
+initialState :: Input -> AppState
+initialState input = defaultState { baseUrl = input.baseUrl }
 
 handleAction
   :: forall slots output m

--- a/src/MPFS/App/RuntimeConfig.js
+++ b/src/MPFS/App/RuntimeConfig.js
@@ -1,0 +1,12 @@
+export const readApiBaseUrlImpl = (just) => (nothing) => () => {
+  if (typeof window === "undefined") {
+    return nothing;
+  }
+
+  const baseUrl = window.MPFS_BASE_URL;
+  if (typeof baseUrl !== "string" || baseUrl === "") {
+    return nothing;
+  }
+
+  return just(baseUrl);
+};

--- a/src/MPFS/App/RuntimeConfig.purs
+++ b/src/MPFS/App/RuntimeConfig.purs
@@ -1,0 +1,24 @@
+module MPFS.App.RuntimeConfig
+  ( apiBaseUrl
+  , readApiBaseUrl
+  , resolveBaseUrl
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+
+resolveBaseUrl :: Maybe String -> String
+resolveBaseUrl = case _ of
+  Nothing -> "/api"
+  Just baseUrl -> baseUrl
+
+readApiBaseUrl :: Effect (Maybe String)
+readApiBaseUrl = readApiBaseUrlImpl Just Nothing
+
+apiBaseUrl :: Effect String
+apiBaseUrl = resolveBaseUrl <$> readApiBaseUrl
+
+foreign import readApiBaseUrlImpl
+  :: (String -> Maybe String) -> Maybe String -> Effect (Maybe String)

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -3,11 +3,14 @@ module Main where
 import Prelude
 
 import Effect (Effect)
+import Effect.Class (liftEffect)
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
 import App as App
+import MPFS.App.RuntimeConfig as RuntimeConfig
 
 main :: Effect Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
-  runUI App.component unit body
+  base <- liftEffect RuntimeConfig.apiBaseUrl
+  runUI App.component { baseUrl: base } body

--- a/test/Test/MPFS/App/RuntimeConfigSpec.purs
+++ b/test/Test/MPFS/App/RuntimeConfigSpec.purs
@@ -1,0 +1,16 @@
+module Test.MPFS.App.RuntimeConfigSpec (spec) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import MPFS.App.RuntimeConfig (resolveBaseUrl)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "MPFS App RuntimeConfig" do
+  it "defaults the MPFS API base to /api" do
+    resolveBaseUrl Nothing `shouldEqual` "/api"
+
+  it "uses an injected MPFS API base when present" do
+    resolveBaseUrl (Just "https://x") `shouldEqual` "https://x"

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -14,6 +14,7 @@ import Test.AppWriteSpec as AppWriteSpec
 import Test.FactsSpec as FactsSpec
 import Test.MPFS.CageSpec as CageSpec
 import Test.MPFS.ClientSpec as ClientSpec
+import Test.MPFS.App.RuntimeConfigSpec as RuntimeConfigSpec
 import Test.MPFS.ProofSpec as ProofSpec
 import Test.MPFS.SecondOracleCsmtVerifySpec as SecondOracleCsmtVerifySpec
 import Test.MPFS.SecondOracleClientSpec as SecondOracleClientSpec
@@ -34,6 +35,7 @@ main = do
       AppWalletSpec.spec
       AppWriteSpec.spec
       CageSpec.spec
+      RuntimeConfigSpec.spec
       FactsSpec.spec
       ProofSpec.spec
       SecondOracleClientSpec.spec


### PR DESCRIPTION
Resolves #60. Runtime `window.__MPFS_BASE_URL__` (default `/api`) + a `preview.yml` publishing `dist/` to preview.dev.plutimus.com via paolino/dev-assets/static-preview. Draft while the preview is built + used.